### PR TITLE
Fix for issue #41 -- don't ignore CLOSED error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![DOI](https://zenodo.org/badge/116042298.svg)](https://zenodo.org/badge/latestdoi/116042298)
 
+https://mybinder.org/v2/gh/hsolbrig/pyshex/master
 
 
 This package is a reasonably literal implementation of the [Shape Expressions Language 2.0](http://shex.io/shex-semantics/).  It can parse and "execute" ShExC and ShExJ source.
@@ -36,6 +37,7 @@ This package is a reasonably literal implementation of the [Shape Expressions La
 * 0.7.2 -- Upgrade error reporting
 * 0.7.3 -- Report using namespaces, enhance PrefixLib to inject into a module
 * 0.7.4 -- Added '-ps', '-pr', '-gn', '-pb' options to CLI
+* 0.7.5 -- Fix CLOSED issue in evaluate call (issue 41)
 
 ## Installation
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This package is a reasonably literal implementation of the [Shape Expressions La
 * 0.7.3 -- Report using namespaces, enhance PrefixLib to inject into a module
 * 0.7.4 -- Added '-ps', '-pr', '-gn', '-pb' options to CLI
 * 0.7.5 -- Fix CLOSED issue in evaluate call (issue 41)
+* 0.7.6 -- bump version due to build error
 
 ## Installation
 ```bash

--- a/notebooks/CLI.ipynb
+++ b/notebooks/CLI.ipynb
@@ -76,11 +76,11 @@
     {
      "ename": "SystemExit",
      "evalue": "0",
-     "output_type": "error",
      "traceback": [
       "An exception has occurred, use %tb to see the full traceback.\n",
       "\u001b[0;31mSystemExit\u001b[0m\u001b[0;31m:\u001b[0m 0\n"
-     ]
+     ],
+     "output_type": "error"
     }
    ],
    "source": [

--- a/pyshex/shape_expressions_language/p5_5_shapes_and_triple_expressions.py
+++ b/pyshex/shape_expressions_language/p5_5_shapes_and_triple_expressions.py
@@ -73,7 +73,7 @@ def satisfiesShape(cntxt: Context, n: Node, S: ShExJ.Shape, c: DebugContext) -> 
                               f"{len(non_matchables)} non-matching triples on a closed shape"))
                     print(c.i(1, "", list(non_matchables)))
                     print()
-                rslt = False
+                return False
 
 
         # Evaluate the actual expression.  Start assuming everything matches...

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 6):
 
 setup(
     name='PyShEx',
-    version='0.7.4',
+    version='0.7.5',
     packages = find_packages(exclude=['tests']),
     url="http://github.com/hsolbrig/PyShEx",
     license='Apache 2.0',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 6):
 
 setup(
     name='PyShEx',
-    version='0.7.5',
+    version='0.7.6',
     packages = find_packages(exclude=['tests']),
     url="http://github.com/hsolbrig/PyShEx",
     license='Apache 2.0',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import os
 refresh_files = False
 
 # True means skip the disease test
-skip_diseases = False
+skip_diseases = True
 
 datadir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 

--- a/tests/data/earl_report.ttl
+++ b/tests/data/earl_report.ttl
@@ -43,7450 +43,7 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.168792" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.263219" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.700127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.197618" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.843605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.427528" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1E0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.787523" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.670896" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.002431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.675048" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.539876" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.293727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.762416" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.587603" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.063675" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.070857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.664570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.460779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.816499" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.488975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.469894" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.511754" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.358837" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.084934" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.914811" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23_pass-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.302342" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.293133" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.669732" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.680480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.169173" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.283812" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.233068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.357227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.686075" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#repeated-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.348585" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.569814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.559264" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.201203" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.309143" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.023627" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.864720" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.839225" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.641634" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.586753" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.772666" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.420107" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.302150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.495875" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.143761" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.105747" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.930306" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.377912" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.981970" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.816219" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.315268" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.269702" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.910410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.411076" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.904068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.179574" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.812518" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.094630" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.150375" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.943713" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.859737" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.303451" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.643614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.447897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.685283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.670815" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.077965" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.854532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.214801" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.723480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.530496" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.975307" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.407028" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.629005" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.179103" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.679716" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.087740" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.995652" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.720503" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.668712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.388404" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.807566" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.968688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.007824" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.138677" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.005822" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.823796" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.780075" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.757699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.032213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.247116" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.185146" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.131808" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.446489" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.568375" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.720276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.070972" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.754969" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.056466" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.784445" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.573017" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.011440" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.221233" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.142542" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.631936" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.801154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.514137" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.665723" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.903970" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.272592" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.475976" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.635211" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.578251" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.727388" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.713709" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.578420" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.556220" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.017552" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.181403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.850953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.031671" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.619187" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.900529" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.229317" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.247735" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.302389" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.619488" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.024006" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.612331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.457624" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.820246" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.002161" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.520281" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.334589" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.327281" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.135371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.816884" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.682874" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.441585" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.199021" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.012999" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.266709" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.834130" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.697567" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.574391" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.251522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.263752" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.507237" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.703405" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.249368" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.495548" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.882024" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.880629" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.651795" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.924166" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.715543" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.400503" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.394306" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.287476" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.104479" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.989805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.612240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.395906" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.220402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.540433" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.559943" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.238862" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.835326" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.899710" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.477711" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.100380" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.959517" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.754617" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.262755" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.530833" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.255838" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.604685" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.549062" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.722178" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.202501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.880823" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.324240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.988934" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.908145" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.569529" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.115266" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.500591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.757727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.158369" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.769453" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.096589" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.866704" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.855444" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.612991" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.537182" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.187564" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.209278" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.916153" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.278531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.926940" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.313779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.641697" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.738140" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.250976" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.505156" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.185614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.898810" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.603989" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.488288" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.518421" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.434986" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.715308" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.951374" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.923577" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.103232" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.536842" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.978990" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.412069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.869460" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.226514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.382914" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.566459" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.938169" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.291784" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.309296" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.235801" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.904644" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.687501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.701042" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.000135" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.607805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.998467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.518913" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.678510" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.590467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.691045" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#simple-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.829499" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.439722" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.094461" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.981502" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.428110" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.582864" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.547700" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.330726" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.242887" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.780105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.808399" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.486386" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.687063" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.831311" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.375115" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.223136" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.851715" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.994175" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.319179" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.220056" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.679273" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.527148" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.381857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.423064" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.511071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.561511" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.962562" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.502276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.158590" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.393060" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.736017" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.202300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.811435" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.204087" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.510242" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.219619" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.657972" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.424046" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.763867" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.707909" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.523235" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.501392" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.552959" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.741383" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.978170" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.582987" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.954992" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.772885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.113587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.295106" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.820012" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.652743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.396748" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.280054" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.321035" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.876997" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.566589" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.624495" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.449140" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.617644" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.915716" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.888563" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.884288" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.210417" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.503985" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.224649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.755331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.355681" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.272059" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.676184" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.911282" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.188983" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.267532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.380762" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.431656" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.045468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.743412" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.031307" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.142670" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.311031" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.823673" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.360500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.390624" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.920093" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.804346" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.818420" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.524658" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.297531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.661444" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.593009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.267780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.525338" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.108046" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.371125" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.524558" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.175578" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.047870" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.201139" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.161620" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.990352" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.725631" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.541638" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.676016" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.750780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.464813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.337590" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.954499" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.070162" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.400487" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.565413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.414699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.489347" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.219469" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.442756" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.398611" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.730434" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.813645" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.544517" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.454001" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.599058" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.376433" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.973830" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.661116" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.435103" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.930258" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.021030" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.638139" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.531315" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.471471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.540494" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.122080" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.264005" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.898607" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.135443" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.970627" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.405755" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.731356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.876841" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.562077" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.835129" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.335285" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.212380" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.013103" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.701569" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.574547" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.055390" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.002714" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.973715" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.466762" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.099043" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.595331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.746327" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.418558" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.162437" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.206259" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.617878" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.775598" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.279805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.035790" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.499727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.363594" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.041688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.079284" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.197004" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.170897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.215816" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.710950" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.209212" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.654083" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.436295" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.193091" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.020098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.322809" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.239253" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.421365" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.576911" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.578035" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.492100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.199188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.287672" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.131332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.587703" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.272942" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.209734" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.789350" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.507766" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.906410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.142605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.081573" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.193377" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.343495" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.167193" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.773995" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.562105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.924490" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.105105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.707718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.812349" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.341975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.959800" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.404152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.128782" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.931958" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.771476" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.598834" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.848401" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.458826" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.194787" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.692405" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.626255" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.414867" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.313087" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.553502" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.281256" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.814115" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.871937" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.230739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.748572" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.419607" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.800473" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.795606" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.222462" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.111605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.514964" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.913510" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.026316" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.474971" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.018135" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.753007" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.327894" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.290613" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.629305" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.550643" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.167563" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23Annot3Code2-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.805411" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.924021" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.744927" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.994694" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.571284" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.109793" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.624370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.861042" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.494367" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.255313" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.225861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.841559" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.582218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.412067" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.426120" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.691403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.870535" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.100735" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.055901" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.789688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.886283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.435198" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.794774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.312267" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.218705" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.317130" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.931897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.009294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.119676" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.556814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.547067" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.537978" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.533461" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.351874" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.459965" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.809719" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.150379" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.545141" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.489451" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.035013" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.318634" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.243808" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.498521" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.695413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.487537" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.475217" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.551348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.510413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.648020" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.530120" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.369882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.199148" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.582589" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.195712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.896482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.455129" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.492026" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.132967" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.114045" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.303196" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.196610" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.547231" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.271465" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.179529" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.307098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.769840" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.454954" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.066773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.049526" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.824565" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.741270" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.465097" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.283591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.598442" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.099662" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.973438" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.625834" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.240157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.571851" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.939508" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.813712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.138784" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.244383" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.004786" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.633476" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.156310" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.829000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.541418" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.646477" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.215999" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.965174" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.936780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.523543" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.361899" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.172179" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.009890" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.260515" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.996272" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.887598" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.608410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.039705" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.772755" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.039549" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.071628" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.610949" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.973478" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.451079" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.988799" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.595531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.791531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.338762" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.946659" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.445069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.788069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.396763" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.681421" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.151902" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.124861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.986156" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.858837" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.464511" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.275243" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.464605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.165840" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.529234" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.125873" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.283502" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.321699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.301918" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.021982" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.964210" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.839701" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.359235" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.988402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.224846" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.255907" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.712893" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.800465" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.093605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.892922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.499905" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.567792" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.543743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.191008" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.447356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.182030" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.947860" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.491813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.553112" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.849060" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.605133" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.134082" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.528157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.514717" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.124383" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.062857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.255467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.185395" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.774671" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.513297" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.966975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.103994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.665059" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.577265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.041018" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.648151" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.035558" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.298734" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.660789" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.703542" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.621715" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.117881" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.734332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.345051" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.385986" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.536041" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.534482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.076947" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.303546" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.389737" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.278881" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.482487" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.927960" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.804956" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.077402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.009564" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.296485" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.311414" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.376745" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.496075" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.385287" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.177983" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.541558" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.547440" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.518412" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.443095" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.017154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.469928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.974525" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.247775" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.756459" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.944522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.555974" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.236788" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.174564" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.719213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.603842" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.886263" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.559201" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.849612" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.759072" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.352513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.146138" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.312015" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.018328" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.600657" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.115158" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.630861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.915951" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.927536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.367425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.504414" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.763680" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.069564" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.130444" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.511349" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.275196" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.734810" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.051275" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.699521" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.000127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.408606" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.944213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.627377" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.583979" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.321831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.465179" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.751303" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.641726" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.747229" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.305475" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.751128" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.665526" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.556773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:47.798915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.348338" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.982514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.181782" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.167186" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.541896" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.109510" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.743601" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.564176" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.599843" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.838333" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.606882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.341643" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.255323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.173376" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.553808" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.964086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.694891" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.295425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotcloseCode1-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.939665" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.259348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.845380" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.930206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.672371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.716547" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.624862" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.942497" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.593928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.204773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.790727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.437598" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.150846" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.598446" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.615833" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.205012" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotAIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.334143" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.892173" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.007098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.062675" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.235531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.653135" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.783750" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.243294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.610691" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.647993" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.473314" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.644609" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.796455" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.295492" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.794352" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.028166" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.138294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.484209" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.672283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.236525" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.880290" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.008743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.058658" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.738896" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.075599" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.935283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.051713" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.998867" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.786280" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.908530" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.588822" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.431537" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.711728" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.903140" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.745678" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.324847" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.222284" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.327739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.065989" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.243893" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.259173" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.595764" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.392721" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.107910" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.907881" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.043170" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.197482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.498142" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.995512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.028413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.827403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.651032" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.934439" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.389645" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.330870" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.805968" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.327037" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.515243" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.356181" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.862184" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.291290" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.057638" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.089048" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.706971" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.789283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.730539" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.635105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:41.880591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.867222" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.986545" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.920073" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.299284" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.450206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.002591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.188962" ;
+            ns1:date "2019-03-05T12:11:15.690310" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteral-dot_pass-iri-equal> .
@@ -7495,880 +52,34 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.724655" ;
+            ns1:date "2019-03-05T12:11:11.254256" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.307887" ;
+            ns1:date "2019-03-05T12:11:15.882484" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.121252" ;
+            ns1:date "2019-03-05T12:11:11.497868" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.210879" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.267193" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.534172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.092008" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.615188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.352909" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.579047" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:42.374054" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.317081" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.979611" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.806827" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.127091" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.631154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.229929" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.858397" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.652371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.227654" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.622831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.483532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.248977" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.276196" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.474738" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.613071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.043498" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.298851" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.371748" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.917232" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.546127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.279512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.896923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.402276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.945251" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.958667" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.704682" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.441273" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.011539" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.591244" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.800522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.305279" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.719702" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.767481" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.190917" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.175704" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.881738" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.074553" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.865859" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.462790" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.587634" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.854690" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.215102" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.845613" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.767212" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.935621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.341649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.416302" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.471133" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.608976" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.272294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.027402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.640267" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.085732" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.969238" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.661649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.949428" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.433110" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.368622" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.551501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.633847" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.492452" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.690839" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.216120" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.016083" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.449552" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.639534" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.892167" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.768844" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.233364" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.901611" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.025045" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.478931" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.555938" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.067027" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.739727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.218252" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.727421" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.242413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.189191" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.863583" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.731817" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.877462" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.321358" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.059386" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.201783" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.050102" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.505713" ;
+            ns1:date "2019-03-05T12:11:10.044225" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass6> .
@@ -8377,484 +88,25 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.429613" ;
+            ns1:date "2019-03-05T12:11:11.501640" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.070620" ;
+            ns1:date "2019-03-05T12:11:12.204839" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.003102" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.674468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.408101" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:40.526373" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.984053" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.708720" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.992263" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:44.499935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.251503" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.815892" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.690068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.847304" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.307521" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.993155" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.675897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.533098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.907002" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.864346" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.285751" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.315652" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.685060" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.530272" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:48.174052" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.145971" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.828893" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.617619" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.720531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.260216" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:50.417655" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.778743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.562413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.719490" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.013959" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:55.933395" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.514699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.063302" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.819779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.192300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.666115" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.780375" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.438392" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.091257" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:49.616519" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.706764" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.154931" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.439636" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.694575" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.873058" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.657033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.280716" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.259775" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.091881" ;
+            ns1:date "2019-03-05T12:11:14.614672" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri1> .
@@ -8863,142 +115,34 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.427924" ;
+            ns1:date "2019-03-05T12:11:09.995271" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.276155" ;
+            ns1:date "2019-03-05T12:11:16.034778" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.081959" ;
+            ns1:date "2019-03-05T12:11:12.088070" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.648209" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.915956" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.284660" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.560682" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.868730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.029640" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.459623" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.128219" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.656884" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:45.725123" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.495573" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.998160" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.526841" ;
+            ns1:date "2019-03-05T12:11:10.061222" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_fail0> .
@@ -9007,97 +151,187 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:46.962446" ;
+            ns1:date "2019-03-05T12:11:10.216416" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.334440" ;
+            ns1:date "2019-03-05T12:11:10.742311" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.173159" ;
+            ns1:date "2019-03-05T12:11:12.201221" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:43.933572" ;
+            ns1:date "2019-03-05T12:11:11.468751" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.518982" ;
+            ns1:date "2019-03-05T12:11:14.458081" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:51.659859" ;
+            ns1:date "2019-03-05T12:11:08.481990" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:39.664953" ;
+            ns1:date "2019-03-05T12:11:12.946175" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.287432" ;
+            ns1:date "2019-03-05T12:11:12.024316" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.480102" ;
+            ns1:date "2019-03-05T12:11:10.010376" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:57.599967" ;
+            ns1:date "2019-03-05T12:11:11.226368" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.231587" ;
+            ns1:date "2019-03-05T12:11:11.637680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.867701" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.768875" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.883679" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.028373" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.936126" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.449048" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.213593" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.630597" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.519480" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.761946" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_missing> .
@@ -9106,25 +340,223 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:53.920619" ;
+            ns1:date "2019-03-05T12:11:13.222521" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.083560" ;
+            ns1:date "2019-03-05T12:11:12.498712" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:54.087615" ;
+            ns1:date "2019-03-05T12:11:12.043827" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.540833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.377727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.904116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.987754" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.749967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.863986" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.076352" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.034386" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.846446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.825050" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.063195" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.393804" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.731574" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.945258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.800045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.605218" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.327079" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.553646" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.673383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.673287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.638356" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.640272" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p2p3> .
@@ -9133,7 +565,385 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.054166" ;
+            ns1:date "2019-03-05T12:11:11.620298" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.827842" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.721509" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.515994" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.033044" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.527712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.211982" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.392182" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.657283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.007662" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.819512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.523547" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.079980" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.853302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.183043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.738766" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.519541" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.786248" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.759245" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.542434" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.847322" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.027366" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.866001" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.754391" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.511471" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.616373" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.121991" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.654311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.422018" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.212446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.564638" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.312694" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.320028" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.570833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.577318" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.114593" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.497955" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.678707" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.451227" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.590940" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.385931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.794505" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.549698" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLead> .
@@ -9142,7 +952,7441 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:52.683463" ;
+            ns1:date "2019-03-05T12:11:14.746178" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.246724" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.296054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.225691" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.179615" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.013532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.969214" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.403043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.003178" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.694738" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.695694" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.684382" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.135459" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.805071" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.823308" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.067623" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.044921" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.649811" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.404803" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.748065" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.311913" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.449260" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.796920" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.634343" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.257996" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.227021" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.529198" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.351307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.980200" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.805352" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.112232" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.688856" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.041024" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.759452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.333453" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.394786" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.008129" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.524900" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.679650" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.135658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.336798" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.430987" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.379934" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.144931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.558740" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.331577" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.897867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.511921" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.217716" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.089401" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.680169" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.725874" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.786874" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.707882" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.656376" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.013670" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.441396" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.230512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.509272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.406846" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.846393" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.588648" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.557815" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.165964" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.814587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.730831" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.272367" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.863801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.742439" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.546335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.308594" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.796558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.022703" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.376427" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.723380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.123404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.835880" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.820010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.756073" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.437881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.495524" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.748910" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.037610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.119270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.758265" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.070264" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.465746" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.832256" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.703602" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.588897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.856483" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.852884" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.833391" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.694917" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.495450" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.305268" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.491225" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.387799" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.209813" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.018764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.452706" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.302442" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.941591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.072017" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.952219" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.195321" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.371828" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.937209" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.011039" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.728404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.197416" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.464674" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.802085" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.964776" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.593222" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.829000" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.064503" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.765583" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.622539" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.714778" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.465846" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.837413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.614859" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.213098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.679816" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.234285" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.623723" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.074025" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.413562" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.159954" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.849886" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.118745" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.566252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.841145" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.822726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.142488" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.945329" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.817867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.575962" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.445357" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.336335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.940251" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.201970" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.801915" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.023801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.505968" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.561396" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.103304" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.782888" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.472414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.970329" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.626047" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.563915" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.666010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.254805" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.839252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.423982" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.308909" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.486518" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.583680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.645737" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.120946" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.939311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.617007" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.858124" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.812076" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.626725" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.034819" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.145130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.529434" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.575665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.842305" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.140668" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.028420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.719575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.287472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.597397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.246191" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.976702" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.552387" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.698171" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.379799" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.139683" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.169635" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.263333" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.916648" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.047306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.634571" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.672462" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.461159" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.671006" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.914468" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.713676" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.073735" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.026797" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.768794" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.147081" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.368661" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.189355" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.871592" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.337525" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.190603" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.291642" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.820946" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.192396" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.641849" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.441604" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.862452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.244633" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.076903" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.873683" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.126797" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.242378" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.490377" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.838024" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.345630" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.301776" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.167817" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.734906" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.671854" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.427617" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.961177" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.792850" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.413384" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.158432" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.130643" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.384614" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.629653" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.432723" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.338108" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.180396" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#simple-group> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.475518" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.778205" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.505635" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.270106" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.014906" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.857665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.762561" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.409501" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.684685" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.933299" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.104762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.788303" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.267105" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.333627" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.040774" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.998911" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.179481" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.782965" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.230814" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.512422" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.390903" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.307811" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.179844" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.534740" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.797276" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.738932" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.803317" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.516360" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.526171" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.450437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.693031" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.054807" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.057307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.705625" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.674619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.355341" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.876800" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.101621" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.432050" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.624656" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.900341" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.017421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.469020" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.384894" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.730169" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.464512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.235257" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.953691" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.638122" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.669587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.222598" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.287569" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.112369" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.238266" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.958508" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.184180" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.435424" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.424011" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.477972" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.998512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.697859" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.119949" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.529367" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.544456" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.701611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.310491" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.149232" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.987741" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.292946" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.355998" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.428446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.978554" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.369708" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.492695" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.561933" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.991994" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.203786" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.588120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.877429" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.745761" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.553350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.579639" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.827472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.610311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.778880" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.478203" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.667831" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.791034" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.735343" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.538902" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.843295" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.740067" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.361057" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.755189" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.020130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.895919" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.005941" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.568419" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.724560" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.342143" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.089104" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.887287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.957472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.344130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.920239" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.020780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.560272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.896553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.733743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.420963" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.508791" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.372487" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.563414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.295248" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.078893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.001755" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.396343" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.398233" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.720867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.183491" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.042772" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.824417" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.221023" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.461659" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.284159" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.585057" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.472512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.539690" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.723282" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.050195" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.305397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.389019" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.569937" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.908674" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.515175" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.057004" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.268448" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.794516" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.081702" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.374702" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.766228" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.306360" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.023624" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.374962" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.596186" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.983458" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.369859" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.768471" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.085134" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.921290" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.079411" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.836018" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.123190" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.037852" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.262850" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.980743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.592738" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.456383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.517000" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.845189" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.409889" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.556673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.564039" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.051072" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.691685" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.973621" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.549801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.474403" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.720124" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.110547" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.485313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.315910" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.724210" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.085474" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.931682" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.685040" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.677628" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.037981" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.689512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.109680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.349489" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.711813" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.974856" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.031104" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.029052" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.147001" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.696290" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.892237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.205973" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.710880" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.472955" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.217633" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.639665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.986489" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.257785" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.768617" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.211663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.205074" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.331455" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.845350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.880029" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.128369" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.922796" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.323599" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.707285" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.910167" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.774335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.131099" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.200452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.928872" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.727182" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.065604" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.102820" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.606899" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.985603" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.279997" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.693238" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.002449" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.596925" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.047071" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.892308" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.316625" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.575512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.775224" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.267663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.663447" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.657673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.013701" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.926350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.070803" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.387039" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.845962" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.554984" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.417007" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.375804" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.411482" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.473399" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.558723" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.096174" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.883275" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.856015" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.636449" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.480436" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.016918" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.287591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.573679" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.653530" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.393398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.650354" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.710210" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.210979" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.115273" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.832930" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.317164" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.682190" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.270847" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.773165" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.808823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.363577" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.956376" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.807110" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.415439" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.537525" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.898953" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.520899" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.190427" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.972939" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.104915" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.415429" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.650590" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.667733" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.491337" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.326890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.899938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.704075" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.812387" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.656912" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.003418" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.964700" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.835782" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.788640" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.559790" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.340127" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.728519" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.278851" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.191832" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.867528" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.780619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.993995" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.252503" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.871186" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.090410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.862330" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.777117" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.029561" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.816974" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.498823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.846758" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.280469" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.793053" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.249404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.052361" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.888601" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.689592" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.387109" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.773841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.486999" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.919102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.454685" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.296965" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.715650" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.961258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.859372" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.241045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.119335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.327811" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.240085" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.605175" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.853010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.599966" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.880775" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.195270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.165956" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.952164" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.771944" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.097535" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.937985" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.725216" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.376582" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.878519" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.197863" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.174751" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.107095" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.731492" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.762676" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.524783" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.833002" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotcloseCode1-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.036875" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.367082" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.645745" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.106010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.434970" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.807177" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.700956" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.781372" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.553330" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.128567" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.307259" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.749974" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.572466" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.798222" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.249722" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.178397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.438003" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.735669" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.812634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.299645" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.398933" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.498963" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.660528" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.744301" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.980561" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.997335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.297966" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.469493" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.315879" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.878625" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.941981" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.606131" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.185472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.287301" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.391608" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.092488" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.584665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.860483" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.870302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.156213" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.784111" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.186645" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.482593" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.755413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.253588" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.807163" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.441729" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.283575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.617473" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.545761" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.460122" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.355378" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.761901" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.082281" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.883589" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.567883" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.662345" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.114739" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.445933" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.642998" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1E0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.651378" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.875138" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.745908" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.925779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.229778" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.702550" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.947673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.610153" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.505166" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.801297" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.707284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.959441" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.193637" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.224081" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.747116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.184977" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.485903" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.327238" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.611086" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.571823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.152271" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.248922" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.095559" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.216817" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.937833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.548709" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.753618" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.484536" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.463840" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.346712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.322152" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.220971" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.077932" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.275670" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.153265" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.172751" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.587303" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.156030" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.037313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.555184" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.567275" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.821801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.762306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.789890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.800952" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.346371" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.836636" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.662550" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.352227" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.519333" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.100280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.141935" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.284414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.531738" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.397886" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.854566" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.821498" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.567976" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.196186" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.119241" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.494104" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.326557" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.502406" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.560305" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.162365" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.766935" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:02.026499" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.271043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.065087" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.459128" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.809095" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.696763" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.115916" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.683470" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.864095" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.924646" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.032389" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.867380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.234793" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.417437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.249981" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.208365" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.737687" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.214272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.649016" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.952771" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.693199" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.654126" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.123893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.795350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.682780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.208252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.408968" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.763582" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.820829" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.258903" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.510156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.969663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.675889" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.754362" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.741015" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.577827" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.454900" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.051571" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.419379" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.301791" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.055027" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.769725" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.126850" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.381967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.770565" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.303697" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.714330" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.341506" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.533156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.541517" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.045034" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.681101" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.047267" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.452999" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.282454" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.090223" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.381313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.849567" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.574097" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.347882" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.205208" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.445412" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.793495" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.589143" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.285237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.474395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.776289" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.915218" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.684577" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:06.924204" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.200311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.110152" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.714489" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.667666" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.060609" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.095698" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.983951" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.171877" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#repeated-group> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.295732" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.992817" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.941251" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.718318" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.439366" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:01.126601" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.351595" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.907942" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.349185" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.317405" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.188986" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.049657" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.860339" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.536969" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.359793" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.664250" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.868931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.134280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.933313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.750848" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.815460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.173947" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.319502" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.912618" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.583346" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.402798" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.783397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.230411" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.816354" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.992610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.675111" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.280316" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.124707" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.732074" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.657732" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.106973" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.743683" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.441663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23_pass-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.780642" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.479900" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.234866" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.699204" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.479706" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.238908" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.756899" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.012992" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.364719" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.225840" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.003748" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.582879" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.323281" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.135899" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.277452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:16.021396" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.194039" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-equal> .
@@ -9151,10 +8395,766 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-05T11:54:56.148887" ;
+            ns1:date "2019-03-05T12:11:12.082307" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:09.896454" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.348415" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.707345" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.750037" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.633226" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.171124" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.732854" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotAIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.873465" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.522932" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.807273" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:08.706900" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.748716" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.363483" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.403236" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.580847" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.467097" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.927851" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.714292" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.949244" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.977055" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.761724" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.291938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.099288" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.732117" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.342373" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.911285" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.853197" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.482431" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.053586" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.699937" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.686198" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.841897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.618756" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.505265" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.828440" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:05.404095" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.274421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.600952" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.853094" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.093356" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.383692" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:04.765787" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.811204" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.017510" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.436414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.494821" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.848277" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.519528" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.548980" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.356480" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.999005" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:07.657940" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.374970" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.738686" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.533141" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.093670" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.255146" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.465742" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.275852" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.664602" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23Annot3Code2-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.787854" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.964551" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:03.824157" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:15.829902" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.579822" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.057232" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:00.563691" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.085790" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.849225" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.738545" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.293640" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.174967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.006793" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.788913" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:12.401672" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:10.513145" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.311034" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:58.866788" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:11.428498" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.802858" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.152441" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:14.545139" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:11:13.347245" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T12:10:59.104728" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
 
 [] dc:issued "2018-11-13"^^xsd:date ;
     foaf:maker <https://github.com/hsolbrig> ;

--- a/tests/data/earl_report.ttl
+++ b/tests/data/earl_report.ttl
@@ -43,3742 +43,7 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.312862" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23Annot3Code2-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.842095" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.066402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.175806" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.711809" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.419783" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.322093" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.218743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.703892" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.540499" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.475264" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.892649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.990604" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.907041" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.750568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.317362" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.085305" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.824668" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.083779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.926756" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.334355" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.170086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.725402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.296279" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.717246" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.508047" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.337930" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteral-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.456702" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.455205" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.283551" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.364874" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.705692" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.994324" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.812922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.739189" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.856915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.812883" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.367923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.695547" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.492416" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.164491" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.759009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.421980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.686576" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.178963" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.195861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.689581" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.094764" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.042143" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.241022" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.361595" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.338000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotAIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.052928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.851074" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.542739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.729166" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.622679" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.470562" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.851682" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.192422" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.009889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.057069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.569784" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.110264" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.975500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.614411" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.105736" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.185099" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.750866" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.006415" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.910601" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.979858" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.168077" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.599907" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.157259" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.431773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.935487" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.828858" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.122002" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.492354" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.559276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.693549" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.470605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.972875" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.595055" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.435781" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotcloseCode1-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.821470" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.108372" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.376248" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.576679" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.867560" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.146764" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.016928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.288622" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.004099" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.806514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.437530" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.054136" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.382154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.493422" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.798307" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.052555" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.472552" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.690842" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.778694" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.689071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.496661" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.106480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.637971" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.953622" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.300282" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.795746" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.871501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.355302" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.807955" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.691131" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.810688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.589753" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.246850" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.286467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.158177" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.987383" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.983000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.883023" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.226863" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.328086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.921294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.790023" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.894057" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#simple-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.445825" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.881699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.726005" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.863127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.660527" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.630087" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.310749" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.947732" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.114799" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.122178" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.068254" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.343460" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.691679" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.421912" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.000614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.649882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.833323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.291889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.598069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.078395" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.656259" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.299402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.114704" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.056816" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.910952" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.312468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.093337" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.380257" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.496172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.838568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.273994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.271763" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.561935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.341250" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.141726" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.504993" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.575833" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.820918" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.875038" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.925034" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.854771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.711105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.929772" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.565512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.270635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.135715" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.184471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.600200" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.046192" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.046771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.791132" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.703643" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.479739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.769851" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.276100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.118107" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.520810" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.814249" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.478471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.405402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.433846" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.355902" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.771938" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.876536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.730049" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.576559" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.670054" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.413155" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.004498" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.737982" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.230300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.544493" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.013450" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.127082" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.126169" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.981384" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.319743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.548239" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.372038" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.277370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.843636" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.345747" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.358512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.244400" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.389456" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.088939" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.127099" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.217157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.016667" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.413528" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.638732" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.359776" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.146783" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.009618" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.427068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.467506" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.323145" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.694503" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.926888" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.134879" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.097692" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.021792" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.914300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.440236" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.725157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.253019" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.767533" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.152682" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.839152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.010381" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.622001" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.511826" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.606072" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.910723" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.123231" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.399151" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.464201" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.518930" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.617617" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.384630" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.883254" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.586831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.423154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.463289" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.616730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.659678" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.861371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.405321" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.023940" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.354814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.939484" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.447532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.477192" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.668860" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.318690" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.567587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.352164" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.858530" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.089773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.205582" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.208680" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.432929" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.411924" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.329427" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.021615" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.005200" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.517589" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.577087" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.513038" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.866641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.902929" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.158088" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.525978" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.595522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.369687" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.632922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.509348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.188461" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.754863" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.001747" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.679434" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.098542" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.376691" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.385898" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.501882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.214629" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.887379" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.334110" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.839079" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.172798" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.645518" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.476523" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.376860" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.643472" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.572173" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.654712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.341309" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.963348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.070371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.839762" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.953932" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.182746" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.648737" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.559415" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.199517" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.684740" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.183947" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.299434" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.814574" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.443061" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.260868" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.871817" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.364878" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.983218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.659948" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.209350" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.520176" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.930400" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.496240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.817197" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.242430" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.046268" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.244382" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.087975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.756874" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.366056" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.609915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.230388" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.077860" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.348566" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.443941" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.752085" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.017536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.373320" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.031185" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.452915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.468988" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.216736" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.181145" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.191726" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.474953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.406340" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.643298" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.365051" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.328943" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.163902" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.346885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.424629" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.817974" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.989731" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.199916" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.414460" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.634793" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.937188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.825101" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.393267" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.606097" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.648685" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.049751" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.079470" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.912848" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.685805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.488752" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.366240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.061831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.891968" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.754993" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.376459" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.081463" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.133133" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.518954" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.707514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.714097" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.738621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.382823" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.861498" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.909786" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.268335" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.130276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.459852" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.951197" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.038065" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.416086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.188144" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.154513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.771570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.895130" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.140669" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.484187" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.904753" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.184715" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.415106" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.756437" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.417709" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.237794" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.393577" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.455622" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.900850" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.101827" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.333323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.131236" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.512416" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.636370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.329205" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.940410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.873009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.256297" ;
+            ns1:date "2019-03-05T11:54:54.168792" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape2Shape3> .
@@ -3787,4480 +52,7 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.001980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.343376" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.796756" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.410071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.195220" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.797226" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.213017" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.366427" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.334805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.240530" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.029938" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.984861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.491027" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.785234" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.066042" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.423288" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.709085" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.525138" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.292301" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.745674" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.550710" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.781352" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.868312" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.829557" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.114058" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.568657" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.450068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.659908" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.228605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.701092" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.988544" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.217553" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.286887" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.447923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.460544" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.012153" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.448399" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.350856" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.405227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.032980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23_pass-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.387941" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.583832" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.132935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.083345" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.333213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.158221" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.780689" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.798512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.383866" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.750205" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.969066" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.913115" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.726040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.992478" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.604036" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.602038" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.133921" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.400933" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.045186" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.329697" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.108867" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.098384" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.227289" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.464158" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.136474" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.438854" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.603997" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.707808" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.656385" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.767019" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.472427" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.291223" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.529152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.742122" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.510701" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.741796" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.647073" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.237116" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.374239" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.256991" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.368661" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.847687" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.506102" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.353209" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.137311" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.960436" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.539402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.390574" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.206880" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.244559" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.643996" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.851350" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.909560" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.420131" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.492550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.639611" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.695271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.745976" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.340541" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.558628" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.911227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.499157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.622033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.095217" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.683091" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.712550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.805724" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.765659" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.958314" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.735231" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.143708" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.299931" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.441177" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.905513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:55.011749" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.790434" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.347381" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.590758" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.233864" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.689881" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.720316" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.128150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.899152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.439434" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.427320" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.259249" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:55.004276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.473730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.790369" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.510635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.552607" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.775576" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.481024" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.826074" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.404172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.476512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.515677" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.397245" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.964323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.312576" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:44.353546" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.028382" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.627955" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.009572" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.948048" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.924901" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.949635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.674148" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.038300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.441929" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.592290" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.823822" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.996807" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.523306" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.991159" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.632207" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.305884" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.952047" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.349688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.672539" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.203543" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.439118" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.709241" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.767165" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.676691" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.998159" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.176632" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.559043" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.228809" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.025321" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.762963" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.282527" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.756641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.113953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.915687" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.740644" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.394814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.398431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.503071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.565198" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.942418" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.225288" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.698024" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.014873" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.398899" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.057932" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.053928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.467885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.314568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.716522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.891165" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.585598" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.544183" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.324439" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.500013" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.288709" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.322992" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.976022" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.466647" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.449501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.839482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.486683" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.381668" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.866740" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.499857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.389980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.791599" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.484218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.162890" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.720956" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.415988" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.358425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.892545" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.437067" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.311688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.201255" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.261885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.967772" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.564201" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.592471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.614370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.878677" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.488079" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.536142" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.720908" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.314109" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.345832" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.651958" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.340943" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.887975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.804114" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.148532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.371500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.690425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.522397" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.417780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.342587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.575990" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.336779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.818242" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.428820" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.119267" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.443146" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.766727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.926105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.832482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.216870" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.663073" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.906361" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.266213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.733045" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.428667" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.194692" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.025470" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.460120" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.117443" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.298355" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.917969" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.189190" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.894328" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.063483" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.493055" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.595967" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.806369" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.322998" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.207536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.511080" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.930031" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.376522" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.027405" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.977202" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.934131" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.141725" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.231950" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.771211" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.452802" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.405953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.990644" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.833292" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.708086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.972067" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.280039" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.922171" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.331240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.699070" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.597425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.518774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.410062" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.546711" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.706052" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.945550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.632863" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.504624" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.487294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.664822" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.321469" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.484005" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.483747" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.039835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.668823" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.700097" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.333065" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.355269" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.336651" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.928433" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.729740" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.362300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.509438" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.846923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.092843" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.735370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.896980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.023665" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.076666" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.073245" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.461918" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.608874" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.419137" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.819898" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.303967" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.325774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.399315" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.542774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.488356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.593514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.040962" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.570427" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.535454" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.503090" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.609785" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.620795" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.419724" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.730419" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.429187" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.582301" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.744256" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.888204" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.026011" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.033984" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.496570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.020272" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.579220" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.608906" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.802645" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.635354" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.816429" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.933451" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.308933" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.856550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.546524" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.037515" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.624753" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.840859" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.764578" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.162356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.034772" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.533078" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.480312" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.479866" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.944004" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.284835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.379786" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.889413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.985853" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.598652" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.677626" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.755160" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.618270" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.786206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.709394" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.884374" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.539169" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.315531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.725482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.524224" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.630138" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.255192" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.213230" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.150524" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.533018" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.343430" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.248237" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.013987" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.456971" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.304991" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.101431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.423190" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.006051" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.732961" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.507889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.280555" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.388868" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.973384" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.326477" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.280229" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.820402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.301541" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.224492" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.665421" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.887003" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#repeated-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.224597" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.845882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.581458" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:55.007190" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.361021" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.232825" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.828621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.907452" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.413029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.774736" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.312901" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.941230" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.996502" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.283381" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.048939" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:42.935206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.458703" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.306614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.346542" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.672536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:47.310047" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.619407" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.575660" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.817757" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.555923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.172192" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.054655" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.977813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.177681" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.967909" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.352730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.549523" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.319336" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.298884" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.101750" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.166585" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.670844" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.285038" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.171692" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.262515" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:45.214922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.404656" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.956888" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.327585" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.514555" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.963304" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.323670" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.106413" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.287353" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.573000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.250635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.361727" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.665023" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.862540" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.716640" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.319466" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.807928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.968336" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.357468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.277042" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.718936" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.132572" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.898104" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.554332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.836116" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.914360" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.921468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.713137" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.499093" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.899656" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.504211" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.279750" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.342373" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.266323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.151733" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.123590" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.170248" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.338774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:43.741984" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.787718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.626059" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.816331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.937600" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.955342" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.774905" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.394398" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.409355" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.522658" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.835774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.041706" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.075108" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.046033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.057883" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.776409" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.425725" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:39.201311" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.110508" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.398519" ;
+            ns1:date "2019-03-05T11:54:56.263219" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotCode1_pass> .
@@ -8269,457 +61,7 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.776335" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.537034" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.402398" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.916233" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.189067" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.878556" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.794227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.395438" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.627978" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.265068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.467830" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.535912" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.672249" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.580601" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.327618" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.062063" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.067835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.449774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:40.471331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.538090" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.241018" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.759779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.049453" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.376103" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.090568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.716455" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.972098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.387531" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.801802" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.062197" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.074065" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.589440" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.183137" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.221525" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.529391" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.571187" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.113040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.987468" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.417880" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.936554" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.914427" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.861440" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.920108" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.150150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.734748" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.036224" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.849188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.070831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.829513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.305147" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.813258" ;
+            ns1:date "2019-03-05T11:54:54.700127" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__passIo1> .
@@ -8728,412 +70,25 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.371199" ;
+            ns1:date "2019-03-05T11:54:46.197618" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.360100" ;
+            ns1:date "2019-03-05T11:54:52.843605" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.102441" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.437556" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.809798" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.681023" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:41.733248" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.645345" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.720575" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.844275" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.307568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.274259" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.500255" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.292485" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.532471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.213332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.294988" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.939785" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.409233" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.956833" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.627493" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.199701" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.044669" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.371905" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:54.526218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:46.614894" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.873950" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.256194" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.739579" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.492952" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.786528" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:52.034292" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.563554" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.003089" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.057642" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.701885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:36.425177" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.557254" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.761009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:49.414168" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:51.506265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:50.947656" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:38.037790" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.999101" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.384864" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:37.246289" ;
+            ns1:date "2019-03-05T11:54:40.427528" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1E0_fail> .
@@ -9142,7 +97,4246 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:48.995143" ;
+            ns1:date "2019-03-05T11:54:44.787523" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.670896" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.002431" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.675048" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.539876" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.293727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.762416" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.587603" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.063675" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.070857" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.664570" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.460779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.816499" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.488975" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.469894" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.511754" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.358837" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.084934" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.914811" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23_pass-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.302342" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.293133" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.669732" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.680480" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.169173" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.283812" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.233068" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.357227" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.686075" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#repeated-group> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.348585" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.569814" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.559264" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.201203" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.309143" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.023627" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.864720" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.839225" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.641634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.586753" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.772666" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.420107" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.302150" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.495875" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.143761" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.105747" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.930306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.377912" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.981970" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.816219" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.315268" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.269702" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.910410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.411076" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.904068" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.179574" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.812518" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.094630" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.150375" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.943713" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.859737" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.303451" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.643614" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.447897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.685283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.670815" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.077965" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.854532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.214801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.723480" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.530496" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.975307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.407028" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.629005" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.179103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.679716" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.087740" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.995652" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.720503" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.668712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.388404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.807566" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.968688" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.007824" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.138677" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.005822" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.823796" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.780075" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.757699" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.032213" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.247116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.185146" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.131808" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.446489" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.568375" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.720276" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.070972" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.754969" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.056466" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.784445" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.573017" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.011440" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.221233" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.142542" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.631936" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.801154" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.514137" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.665723" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.903970" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.272592" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.475976" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.635211" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.578251" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.727388" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.713709" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.578420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.556220" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.017552" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.181403" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.850953" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.031671" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.619187" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.900529" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.229317" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.247735" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.302389" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.619488" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.024006" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.612331" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.457624" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.820246" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.002161" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.520281" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.334589" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.327281" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.135371" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.816884" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.682874" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.441585" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.199021" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.012999" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.266709" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.834130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.697567" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.574391" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.251522" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.263752" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.507237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.703405" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.249368" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.495548" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.882024" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.880629" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.651795" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.924166" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.715543" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.400503" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.394306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.287476" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.104479" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.989805" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.612240" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.395906" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.220402" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.540433" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.559943" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.238862" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.835326" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.899710" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.477711" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.100380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.959517" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.754617" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.262755" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.530833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.255838" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.604685" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.549062" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.722178" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.202501" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.880823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.324240" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.988934" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.908145" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.569529" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.115266" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.500591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.757727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.158369" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.769453" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.096589" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.866704" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.855444" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.612991" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.537182" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.187564" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.209278" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.916153" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.278531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.926940" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.313779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.641697" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.738140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.250976" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.505156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.185614" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.898810" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.603989" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.488288" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.518421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.434986" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.715308" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.951374" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.923577" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.103232" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.536842" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.978990" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.412069" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.869460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.226514" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.382914" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.566459" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.938169" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.291784" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.309296" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.235801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.904644" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.687501" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.701042" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.000135" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.607805" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.998467" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.518913" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.678510" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.590467" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.691045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#simple-group> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.829499" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.439722" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.094461" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.981502" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.428110" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.582864" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.547700" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.330726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.242887" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.780105" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.808399" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.486386" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.687063" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.831311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.375115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.223136" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.851715" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.994175" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.319179" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.220056" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.679273" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.527148" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.381857" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.423064" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.511071" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.561511" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.962562" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.502276" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.158590" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.393060" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.736017" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.202300" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.811435" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.204087" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.510242" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.219619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.657972" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.424046" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.763867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.707909" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.523235" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.501392" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.552959" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.741383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.978170" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.582987" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.954992" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.772885" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.113587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.295106" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.820012" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.652743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.396748" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.280054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.321035" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.876997" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.566589" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.624495" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.449140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.617644" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.915716" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.888563" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.884288" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.210417" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.503985" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.224649" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.755331" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.355681" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.272059" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.676184" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.911282" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.188983" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.267532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.380762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.431656" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.045468" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.743412" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.031307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.142670" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.311031" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.823673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.360500" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.390624" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.920093" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.804346" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.818420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.524658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.297531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.661444" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.593009" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.267780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.525338" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.108046" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.371125" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.524558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.175578" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.047870" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.201139" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.161620" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.990352" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.725631" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.541638" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.676016" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.750780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.464813" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.337590" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.954499" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.070162" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.400487" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.565413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.414699" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.489347" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.219469" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.442756" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.398611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.730434" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.813645" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.544517" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.454001" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.599058" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.376433" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.973830" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.661116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.435103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.930258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.021030" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.638139" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.531315" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.471471" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.540494" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.122080" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.264005" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.898607" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.135443" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.970627" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.405755" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.731356" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.876841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.562077" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.835129" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.335285" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.212380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.013103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.701569" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.574547" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.055390" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.002714" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.973715" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.466762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.099043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.595331" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.746327" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.418558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.162437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.206259" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.617878" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.775598" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.279805" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.035790" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.499727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.363594" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.041688" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.079284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.197004" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.170897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.215816" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.710950" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.209212" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.654083" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.436295" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.193091" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.020098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.322809" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.239253" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.421365" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.576911" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.578035" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.492100" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.199188" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.287672" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.131332" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.587703" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.272942" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.209734" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.789350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.507766" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.906410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.142605" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.081573" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.193377" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.343495" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.167193" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.773995" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.562105" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.924490" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.105105" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.707718" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.812349" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.341975" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.959800" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.404152" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.128782" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.931958" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.771476" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.598834" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.848401" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.458826" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.194787" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.692405" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.626255" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.414867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.313087" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.553502" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.281256" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.814115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.871937" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.230739" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.748572" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.419607" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.800473" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.795606" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.222462" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.111605" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.514964" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.913510" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.026316" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.474971" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.018135" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.753007" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.327894" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.290613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.629305" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.550643" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.167563" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23Annot3Code2-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.805411" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.924021" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.744927" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.994694" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLeadTrail> .
@@ -9151,10 +4345,4816 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-02-17T17:24:53.137051" ;
+            ns1:date "2019-03-05T11:54:48.571284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.109793" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.624370" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.861042" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.494367" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.255313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.225861" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.841559" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.582218" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.412067" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.426120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.691403" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.870535" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.100735" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.055901" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.789688" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.886283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.435198" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.794774" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.312267" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.218705" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.317130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.931897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.009294" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.119676" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.556814" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.547067" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.537978" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.533461" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.351874" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.459965" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.809719" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.150379" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.545141" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.489451" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.035013" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.318634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.243808" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.498521" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.695413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.487537" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.475217" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.551348" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.510413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.648020" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.530120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.369882" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.199148" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.582589" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.195712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.896482" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.455129" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.492026" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.132967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.114045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.303196" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.196610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.547231" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.271465" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.179529" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.307098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.769840" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.454954" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.066773" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.049526" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.824565" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.741270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.465097" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.283591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.598442" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.099662" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.973438" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.625834" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.240157" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.571851" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.939508" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.813712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.138784" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.244383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.004786" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.633476" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.156310" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.829000" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.541418" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.646477" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.215999" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.965174" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.936780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.523543" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.361899" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.172179" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.009890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.260515" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.996272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.887598" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.608410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.039705" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.772755" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.039549" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.071628" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.610949" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.973478" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.451079" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.988799" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.595531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.791531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.338762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.946659" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.445069" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.788069" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.396763" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.681421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.151902" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.124861" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.986156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.858837" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.464511" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.275243" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.464605" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.165840" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.529234" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.125873" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.283502" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.321699" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.301918" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.021982" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.964210" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.839701" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.359235" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.988402" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.224846" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.255907" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.712893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.800465" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.093605" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.892922" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.499905" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.567792" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.543743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.191008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.447356" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.182030" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.947860" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.491813" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.553112" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.849060" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.605133" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.134082" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.528157" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.514717" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.124383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.062857" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.255467" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.185395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.774671" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.513297" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.966975" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.103994" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.665059" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.577265" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.041018" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.648151" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.035558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.298734" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.660789" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.703542" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.621715" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.117881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.734332" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.345051" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.385986" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.536041" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.534482" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.076947" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.303546" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.389737" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.278881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.482487" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.927960" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.804956" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.077402" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.009564" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.296485" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.311414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.376745" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.496075" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.385287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.177983" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.541558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.547440" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.518412" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.443095" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.017154" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.469928" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.974525" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.247775" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.756459" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.944522" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.555974" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.236788" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.174564" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.719213" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.603842" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.886263" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.559201" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.849612" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.759072" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.352513" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.146138" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.312015" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.018328" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.600657" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.115158" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.630861" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.915951" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.927536" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.367425" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.504414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.763680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.069564" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.130444" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.511349" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.275196" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.734810" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.051275" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.699521" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.000127" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.408606" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.944213" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.627377" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.583979" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.321831" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.465179" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.751303" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.641726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.747229" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.305475" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.751128" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.665526" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.556773" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:47.798915" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.348338" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.982514" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.181782" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.167186" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.541896" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.109510" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.743601" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.564176" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.599843" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.838333" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.606882" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.341643" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.255323" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.173376" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.553808" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.964086" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.694891" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.295425" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotcloseCode1-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.939665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.259348" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.845380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.930206" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.672371" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.716547" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.624862" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.942497" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.593928" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.204773" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.790727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.437598" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.150846" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.598446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.615833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.205012" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotAIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.334143" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.892173" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.007098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.062675" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.235531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.653135" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.783750" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.243294" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.610691" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.647993" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.473314" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.644609" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.796455" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.295492" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.794352" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.028166" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.138294" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.484209" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.672283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.236525" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.880290" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.008743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.058658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.738896" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.075599" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.935283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.051713" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.998867" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.786280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.908530" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.588822" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.431537" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.711728" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.903140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.745678" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.324847" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.222284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.327739" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.065989" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.243893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.259173" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.595764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.392721" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.107910" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.907881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.043170" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.197482" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.498142" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.995512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.028413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.827403" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.651032" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.934439" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.389645" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.330870" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.805968" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.327037" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.515243" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.356181" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.862184" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.291290" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.057638" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.089048" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.706971" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.789283" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.730539" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.635105" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:41.880591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.867222" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.986545" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.920073" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.299284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.450206" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.002591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.188962" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteral-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.724655" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.307887" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.121252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.210879" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.267193" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.534172" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.092008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.615188" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.352909" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.579047" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:42.374054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.317081" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.979611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.806827" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.127091" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.631154" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.229929" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.858397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.652371" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.227654" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.622831" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.483532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.248977" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.276196" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.474738" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.613071" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.043498" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.298851" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.371748" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.917232" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.546127" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.279512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.896923" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.402276" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.945251" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.958667" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.704682" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.441273" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.011539" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.591244" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.800522" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.305279" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.719702" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.767481" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.190917" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.175704" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.881738" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.074553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.865859" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.462790" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.587634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.854690" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.215102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.845613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.767212" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.935621" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.341649" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.416302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.471133" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.608976" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.272294" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.027402" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.640267" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.085732" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.969238" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.661649" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.949428" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.433110" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.368622" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.551501" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.633847" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.492452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.690839" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.216120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.016083" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.449552" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.639534" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.892167" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.768844" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.233364" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.901611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.025045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.478931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.555938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.067027" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.739727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.218252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.727421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.242413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.189191" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.863583" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.731817" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.877462" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.321358" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.059386" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.201783" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.050102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.505713" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.429613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.070620" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.003102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.674468" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.408101" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:40.526373" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.984053" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.708720" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.992263" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:44.499935" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.251503" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.815892" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.690068" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.847304" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.307521" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.993155" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.675897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.533098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.907002" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.864346" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.285751" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.315652" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.685060" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.530272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:48.174052" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.145971" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.828893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.617619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.720531" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.260216" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:50.417655" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.778743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.562413" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.719490" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.013959" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:55.933395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.514699" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.063302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.819779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.192300" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.666115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.780375" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.438392" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.091257" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:49.616519" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.706764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.154931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.439636" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.694575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.873058" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.657033" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.280716" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.259775" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.091881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.427924" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.276155" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.081959" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.648209" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.915956" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.284660" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.560682" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.868730" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.029640" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.459623" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.128219" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.656884" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:45.725123" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.495573" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.998160" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.526841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:46.962446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.334440" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.173159" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:43.933572" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.518982" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:51.659859" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:39.664953" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.287432" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.480102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:57.599967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.231587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:53.920619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.083560" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:54.087615" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.054166" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:52.683463" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-03-05T11:54:56.148887" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
 
 [] dc:issued "2018-11-13"^^xsd:date ;
     foaf:maker <https://github.com/hsolbrig> ;

--- a/tests/test_cli/output/evaluate/dbsparql6
+++ b/tests/test_cli/output/evaluate/dbsparql6
@@ -14,14 +14,14 @@ select ?item where{?item a <http://w3id.org/biolink/vocab/Protein>} LIMIT 20
 	     ...
 
 
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00734> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 3 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00734> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 4 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00734> a <http://w3id.org/biolink/vocab/Protein> .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00734> ?p ?o}}) (0.25 secs) - 42 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00734> ?p ?o}}) (0.29 secs) - 38 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00734> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P00734>,
-	        "P00734" ;
+	    ns2:identifier <http://identifiers.org/uniprot/P00734> ;
+	    ns1:id "http://identifiers.org/uniprot/P00734" ;
 	    ns1:name "10xCbxE-F2(25-622)",
 	        "10xCbxE-F2(44-327)",
 	        "10xCbxE-F2(44-622)",
@@ -53,28 +53,20 @@ RESULTS:
 	        <http://rdf.wikipathways.org/Pathway/WP2762_r101409/WP/Interaction/da6fc>,
 	        <http://rdf.wikipathways.org/Pathway/WP2762_r101409/WP/Interaction/fc444>,
 	        <http://rdf.wikipathways.org/Pathway/WP4419_r101720/Complex/d0cd7>,
-	        <http://rdf.wikipathways.org/Pathway/WP4419_r101720/Complex/f1433> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/2147>,
-	        <http://identifiers.org/uniprot/C9JV37>,
-	        <http://identifiers.org/uniprot/E9PIT3>,
-	        <http://identifiers.org/uniprot/P00734> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/F2> .
+	        <http://rdf.wikipathways.org/Pathway/WP4419_r101720/Complex/f1433> .
 Errors:
   Focus: http://identifiers.org/uniprot/P00734
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P00734> against shape http://w3id.org/biolink/vocab/NamedThing
-    Triples:
-      <http://identifiers.org/uniprot/P00734> ns1:id <http://identifiers.org/uniprot/P00734> .
-      <http://identifiers.org/uniprot/P00734> ns1:id "P00734" .
-   2 triples exceeds max {0,1}
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00533> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 3 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00533> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 4 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00533> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00533> ?p ?o}}) (0.25 secs) - 25 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00533> ?p ?o}}) (0.29 secs) - 19 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00533> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P00533>,
-	        "P00533" ;
+	    ns2:identifier <http://identifiers.org/uniprot/P00533> ;
+	    ns1:id "http://identifiers.org/uniprot/P00533" ;
 	    ns1:name "EGFR",
 	        "p-6Y-EGFR" ;
 	    ns1:part_of <http://identifiers.org/wikipathways/WP2735_r101333>,
@@ -87,164 +79,133 @@ RESULTS:
 	        <http://rdf.wikipathways.org/Pathway/WP4437_r101698/Complex/d163f>,
 	        <http://rdf.wikipathways.org/Pathway/WP4437_r101698/Complex/da411>,
 	        <http://rdf.wikipathways.org/Pathway/WP4437_r101698/Complex/e0b26>,
-	        <http://rdf.wikipathways.org/Pathway/WP4437_r101698/Complex/ebeb7> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/1956>,
-	        <http://identifiers.org/uniprot/A0A1W2PRR9>,
-	        <http://identifiers.org/uniprot/C9JYS6>,
-	        <http://identifiers.org/uniprot/E9PFD7>,
-	        <http://identifiers.org/uniprot/P00533>,
-	        <http://identifiers.org/uniprot/Q504U8> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/EGFR> .
+	        <http://rdf.wikipathways.org/Pathway/WP4437_r101698/Complex/ebeb7> .
 
   Focus: http://identifiers.org/uniprot/P00533
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P00533> against shape http://w3id.org/biolink/vocab/NamedThing
-    Triples:
-      <http://identifiers.org/uniprot/P00533> ns1:id <http://identifiers.org/uniprot/P00533> .
-      <http://identifiers.org/uniprot/P00533> ns1:id "P00533" .
-   2 triples exceeds max {0,1}
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/O75015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 1 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/O75015> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/O75015> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/O75015> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/O75015> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/O75015> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00736> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 2 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00736> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 3 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00736> a ns1:GeneProduct,
 	        ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00736> ?p ?o}}) (0.25 secs) - 18 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P00736> ?p ?o}}) (0.28 secs) - 9 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P00736> a ns1:GeneProduct,
 	        ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P00736> ;
+	    ns2:identifier <http://identifiers.org/uniprot/P00736> ;
+	    ns1:id "http://identifiers.org/uniprot/P00736" ;
 	    ns1:name "C1r" ;
 	    ns1:part_of <http://identifiers.org/wikipathways/WP2806_r97328>,
 	        <http://rdf.wikipathways.org/Pathway/WP2806_r97328/WP/Interaction/ide953068c_1>,
-	        <http://rdf.wikipathways.org/Pathway/WP2806_r97328/WP/Interaction/ide953068c_2> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/715>,
-	        <http://identifiers.org/uniprot/B4DPQ0>,
-	        <http://identifiers.org/uniprot/F5GWL0>,
-	        <http://identifiers.org/uniprot/F5H1N6>,
-	        <http://identifiers.org/uniprot/F5H1V0>,
-	        <http://identifiers.org/uniprot/F5H2D0>,
-	        <http://identifiers.org/uniprot/F5H3A3>,
-	        <http://identifiers.org/uniprot/F5H3N3>,
-	        <http://identifiers.org/uniprot/F5H6Y3>,
-	        <http://identifiers.org/uniprot/P00736> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/C1R> .
-
-  Focus: http://identifiers.org/uniprot/P00736
-  Start: http://w3id.org/biolink/vocab/Protein
-  Reason:   Testing <http://identifiers.org/uniprot/P00736> against shape http://w3id.org/biolink/vocab/NamedThing
-    Datatype constraint (http://www.w3.org/2001/XMLSchema#string) does not match URIRef <http://identifiers.org/hgnc.symbol/C1R>
+	        <http://rdf.wikipathways.org/Pathway/WP2806_r97328/WP/Interaction/ide953068c_2> .
 
   Focus: http://identifiers.org/uniprot/P00736
   Start: http://w3id.org/biolink/vocab/GeneProduct
   Reason:   Testing <http://identifiers.org/uniprot/P00736> against shape http://w3id.org/biolink/vocab/NamedThing
-    Datatype constraint (http://www.w3.org/2001/XMLSchema#string) does not match URIRef <http://identifiers.org/hgnc.symbol/C1R>
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02745> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 1 triples
+    Node kind mismatch have: Literal expected: nonliteral
+
+  Focus: http://identifiers.org/uniprot/P00736
+  Start: http://w3id.org/biolink/vocab/Protein
+  Reason:   Testing <http://identifiers.org/uniprot/P00736> against shape http://w3id.org/biolink/vocab/NamedThing
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02745> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (1.88 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02745> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02745> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02745> ?p ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02745> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02746> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02746> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02746> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02746> ?p ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02746> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02746> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02747> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02747> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02747> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02747> ?p ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P02747> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P02747> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P08637> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P08637> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P08637> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P08637> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P08637> ?p ?o}}) (0.29 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P08637> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P09871> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P09871> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P09871> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P09871> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P09871> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P09871> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12314> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 3 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12314> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 4 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P12314> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12314> ?p ?o}}) (0.25 secs) - 11 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12314> ?p ?o}}) (0.28 secs) - 8 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P12314> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P12314>,
-	        "P12314" ;
+	    ns2:identifier <http://identifiers.org/uniprot/P12314> ;
+	    ns1:id "http://identifiers.org/uniprot/P12314" ;
 	    ns1:name "FCGR1A" ;
-	    ns1:part_of <http://identifiers.org/wikipathways/WP1836_r101649> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/2209>,
-	        <http://identifiers.org/uniprot/C9JSN8>,
-	        <http://identifiers.org/uniprot/P12314> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/FCGR1A> .
+	    ns1:part_of <http://identifiers.org/wikipathways/WP1836_r101649> .
 
   Focus: http://identifiers.org/uniprot/P12314
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P12314> against shape http://w3id.org/biolink/vocab/NamedThing
-    Triples:
-      <http://identifiers.org/uniprot/P12314> ns1:id <http://identifiers.org/uniprot/P12314> .
-      <http://identifiers.org/uniprot/P12314> ns1:id "P12314" .
-   2 triples exceeds max {0,1}
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12318> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 1 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12318> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P12318> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12318> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P12318> ?p ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P12318> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31994> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.26 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31994> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31994> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31994> ?p ?o}}) (0.25 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31994> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31994> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31995> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31995> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31995> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31995> ?p ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31995> ?p ?o}}) (0.33 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31995> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01589> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 2 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01589> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.41 secs) - 3 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01589> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01589> ?p ?o}}) (0.25 secs) - 16 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01589> ?p ?o}}) (0.27 secs) - 12 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01589> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P01589> ;
+	    ns2:identifier <http://identifiers.org/uniprot/P01589> ;
+	    ns1:id "http://identifiers.org/uniprot/P01589" ;
 	    ns1:name "IL2RA" ;
 	    ns1:part_of <http://identifiers.org/wikipathways/WP1840_r101318>,
 	        <http://identifiers.org/wikipathways/WP2735_r101333>,
 	        <http://rdf.wikipathways.org/Pathway/WP1840_r101318/Complex/c1140>,
 	        <http://rdf.wikipathways.org/Pathway/WP1840_r101318/Complex/e86c7>,
 	        <http://rdf.wikipathways.org/Pathway/WP1840_r101318/Complex/ef234>,
-	        <http://rdf.wikipathways.org/Pathway/WP1840_r101318/Complex/fd52d> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/3559>,
-	        <http://identifiers.org/uniprot/H0Y5Z0>,
-	        <http://identifiers.org/uniprot/P01589>,
-	        <http://identifiers.org/uniprot/Q5W005>,
-	        <http://identifiers.org/uniprot/Q5W006> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/IL2RA> .
+	        <http://rdf.wikipathways.org/Pathway/WP1840_r101318/Complex/fd52d> .
 
   Focus: http://identifiers.org/uniprot/P01589
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P01589> against shape http://w3id.org/biolink/vocab/NamedThing
-    Datatype constraint (http://www.w3.org/2001/XMLSchema#string) does not match URIRef <http://identifiers.org/hgnc.symbol/IL2RA>
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31785> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 2 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31785> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.29 secs) - 3 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31785> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31785> ?p ?o}}) (0.25 secs) - 37 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P31785> ?p ?o}}) (0.28 secs) - 31 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P31785> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P31785> ;
+	    ns2:identifier <http://identifiers.org/uniprot/P31785> ;
+	    ns1:id "http://identifiers.org/uniprot/P31785" ;
 	    ns1:name "IL2RG",
 	        "p-Y-IL2RG" ;
 	    ns1:part_of <http://identifiers.org/wikipathways/WP1840_r101318>,
@@ -270,28 +231,20 @@ RESULTS:
 	        <http://rdf.wikipathways.org/Pathway/WP4066_r101615/Complex/cf260>,
 	        <http://rdf.wikipathways.org/Pathway/WP4066_r101615/Complex/f7a2c>,
 	        <http://rdf.wikipathways.org/Pathway/WP4066_r101615/Complex/f7cfe>,
-	        <http://rdf.wikipathways.org/Pathway/WP4066_r101615/WP/Interaction/b8102> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/3561>,
-	        <http://identifiers.org/uniprot/D6R964>,
-	        <http://identifiers.org/uniprot/D6RBW5>,
-	        <http://identifiers.org/uniprot/D6RDW9>,
-	        <http://identifiers.org/uniprot/H0Y8J6>,
-	        <http://identifiers.org/uniprot/P31785>,
-	        <http://identifiers.org/uniprot/Q5FC10> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/IL2RG> .
+	        <http://rdf.wikipathways.org/Pathway/WP4066_r101615/WP/Interaction/b8102> .
 
   Focus: http://identifiers.org/uniprot/P31785
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P31785> against shape http://w3id.org/biolink/vocab/NamedThing
-    Datatype constraint (http://www.w3.org/2001/XMLSchema#string) does not match URIRef <http://identifiers.org/hgnc.symbol/IL2RG>
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01375> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 3 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01375> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 4 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01375> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01375> ?p ?o}}) (0.25 secs) - 35 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01375> ?p ?o}}) (0.28 secs) - 32 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01375> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P01375>,
-	        "P01375" ;
+	    ns2:identifier <http://identifiers.org/uniprot/P01375> ;
+	    ns1:id "http://identifiers.org/uniprot/P01375" ;
 	    ns1:name "TNF(1-233)",
 	        "TNF(1-34)",
 	        "TNF(1-76)",
@@ -317,68 +270,52 @@ RESULTS:
 	        <http://rdf.wikipathways.org/Pathway/WP3380_r101505/Complex/e45be>,
 	        <http://rdf.wikipathways.org/Pathway/WP3380_r101505/Complex/f1a8a>,
 	        <http://rdf.wikipathways.org/Pathway/WP3380_r101505/Complex/f691c>,
-	        <http://rdf.wikipathways.org/Pathway/WP3380_r101505/WP/Interaction/ab12f> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/7124>,
-	        <http://identifiers.org/uniprot/P01375>,
-	        <http://identifiers.org/uniprot/Q5STB3> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/TNF> .
+	        <http://rdf.wikipathways.org/Pathway/WP3380_r101505/WP/Interaction/ab12f> .
 
   Focus: http://identifiers.org/uniprot/P01375
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P01375> against shape http://w3id.org/biolink/vocab/NamedThing
-    Triples:
-      <http://identifiers.org/uniprot/P01375> ns1:id <http://identifiers.org/uniprot/P01375> .
-      <http://identifiers.org/uniprot/P01375> ns1:id "P01375" .
-   2 triples exceeds max {0,1}
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P20333> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 2 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P20333> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.29 secs) - 3 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P20333> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P20333> ?p ?o}}) (0.25 secs) - 9 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P20333> ?p ?o}}) (0.29 secs) - 7 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P20333> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P20333> ;
+	    ns2:identifier <http://identifiers.org/uniprot/P20333> ;
+	    ns1:id "http://identifiers.org/uniprot/P20333" ;
 	    ns1:name "TNFRSF1B" ;
-	    ns1:part_of <http://identifiers.org/wikipathways/WP4066_r101615> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/7133>,
-	        <http://identifiers.org/uniprot/B5A977>,
-	        <http://identifiers.org/uniprot/P20333> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/TNFRSF1B> .
+	    ns1:part_of <http://identifiers.org/wikipathways/WP4066_r101615> .
 
   Focus: http://identifiers.org/uniprot/P20333
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P20333> against shape http://w3id.org/biolink/vocab/NamedThing
-    Datatype constraint (http://www.w3.org/2001/XMLSchema#string) does not match URIRef <http://identifiers.org/hgnc.symbol/TNFRSF1B>
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01374> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 1 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01374> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.29 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01374> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01374> ?p ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P01374> ?p ?o}}) (0.29 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P01374> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P30968> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.25 secs) - 4 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P30968> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.28 secs) - 5 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P30968> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P30968> ?p ?o}}) (0.25 secs) - 12 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P30968> ?p ?o}}) (0.27 secs) - 10 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P30968> a ns1:Protein ;
-	    ns1:id <http://identifiers.org/uniprot/P30968>,
-	        "P30968" ;
+	    ns2:identifier <http://identifiers.org/uniprot/P30968> ;
+	    ns1:id "http://identifiers.org/uniprot/P30968" ;
 	    ns1:name "GNRHR" ;
 	    ns1:part_of <http://identifiers.org/wikipathways/WP4419_r101720>,
-	        <http://rdf.wikipathways.org/Pathway/WP4419_r101720/Complex/ee0f4> ;
-	    ns1:same_as <http://identifiers.org/ncbigene/2798>,
-	        <http://identifiers.org/uniprot/P30968> ;
-	    ns1:systematic_synonym <http://identifiers.org/hgnc.symbol/GNRHR> .
+	        <http://rdf.wikipathways.org/Pathway/WP4419_r101720/Complex/ee0f4> .
 
   Focus: http://identifiers.org/uniprot/P30968
   Start: http://w3id.org/biolink/vocab/Protein
   Reason:   Testing <http://identifiers.org/uniprot/P30968> against shape http://w3id.org/biolink/vocab/NamedThing
-    Triples:
-      <http://identifiers.org/uniprot/P30968> ns1:id <http://identifiers.org/uniprot/P30968> .
-      <http://identifiers.org/uniprot/P30968> ns1:id "P30968" .
-   2 triples exceeds max {0,1}
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P48551> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.24 secs) - 1 triples
+    Node kind mismatch have: Literal expected: nonliteral
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P48551> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?o}}) (0.27 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P48551> a ns1:Protein .
-SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P48551> ?p ?o}}) (0.24 secs) - 1 triples
+SPARQL: (SELECT ?s ?p ?o {graph ?g {<http://identifiers.org/uniprot/P48551> ?p ?o}}) (0.28 secs) - 2 triples
 RESULTS:
 	<http://identifiers.org/uniprot/P48551> a ns1:Protein .

--- a/tests/test_cli/test_sparql_options.py
+++ b/tests/test_cli/test_sparql_options.py
@@ -55,6 +55,7 @@ class SparqlQueryTestCase(CLITestCase):
         self.do_test([rdf, shex, '-sq', sparql, '-ps', '-gn', graphid, "-pr"], 'dbsparql5', failexpected=True,
                      text_filter=elapsed_filter)
 
+    @unittest.skipIf(True, "Volatile query")
     def test_named_graph_types(self):
         """ Test a Drugbank query with named graph in the query """
         shex = os.path.join(datadir, 'schemas', 'biolink-modelnc.shex')

--- a/tests/test_issues/data/wikidata/disease/Q36855.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q36855.ttl
@@ -1,8 +1,8 @@
 @prefix do: <http://purl.obolibrary.org/obo/DOID_> .
 @prefix doio: <http://identifiers.org/doid/> .
 @prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
-@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
-@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix ns1: <http://wikiba.se/ontology#> .
+@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
 @prefix p: <http://www.wikidata.org/prop/> .
 @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr: <http://www.wikidata.org/prop/reference/> .
@@ -116,10 +116,10 @@ wd:Q36855 rdfs:label "Cúm lợn",
         "مرض جهاز تنفسي",
         "സൂക്ഷ്മാണുവിനാൽ ആതിഥേയജീവിയിൽ ഉണ്ടാവുന്ന രോഗബാധ" ;
     schema:version 853810717 ;
-    ns2:identifiers 10 ;
-    ns2:sitelinks 98 ;
-    ns2:statements 23 ;
-    ns2:timestamp "2019-02-08T13:09:31+00:00"^^xsd:dateTime ;
+    ns1:identifiers 10 ;
+    ns1:sitelinks 98 ;
+    ns1:statements 23 ;
+    ns1:timestamp "2019-02-08T13:09:31+00:00"^^xsd:dateTime ;
     skos:altLabel "2009 H1N1 grip salgını",
         "A",
         "A(H1N1)",
@@ -289,8 +289,8 @@ wd:Q36855 rdfs:label "Cúm lợn",
     p:P699 <http://www.wikidata.org/entity/statement/Q36855-251AFEFE-9357-4819-9345-8658A5817D72>,
         <http://www.wikidata.org/entity/statement/Q36855-C725609A-6F51-4A2F-B451-897C76F77DCD> ;
     p:P910 <http://www.wikidata.org/entity/statement/Q36855-FF9EC242-3136-4C46-8597-0772CDD86794> ;
-    ns1:P227 <http://d-nb.info/gnd/7679861-6> ;
-    ns1:P646 <http://g.co/kg/m/057c6k> ;
+    ns2:P227 <http://d-nb.info/gnd/7679861-6> ;
+    ns2:P646 <http://g.co/kg/m/057c6k> ;
     wdt:P1225 "10644087" ;
     wdt:P1296 "0517808" ;
     wdt:P1417 "science/swine-flu" ;

--- a/tests/test_issues/data/wikidata/disease/Q36956.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q36956.ttl
@@ -1,8 +1,8 @@
 @prefix do: <http://purl.obolibrary.org/obo/DOID_> .
 @prefix doio: <http://identifiers.org/doid/> .
 @prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
-@prefix ns1: <http://wikiba.se/ontology#> .
-@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
 @prefix p: <http://www.wikidata.org/prop/> .
 @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr: <http://www.wikidata.org/prop/reference/> .
@@ -134,10 +134,10 @@ wd:Q36956 rdfs:label "Abïl",
         "ᅟinfekta malsano kaŭzata de bakterio",
         "らい菌の感染によって起こる病気" ;
     schema:version 856153650 ;
-    ns1:identifiers 36 ;
-    ns1:sitelinks 121 ;
-    ns1:statements 96 ;
-    ns1:timestamp "2019-02-11T22:10:55+00:00"^^xsd:dateTime ;
+    ns2:identifiers 36 ;
+    ns2:sitelinks 121 ;
+    ns2:statements 96 ;
+    ns2:timestamp "2019-02-11T22:10:55+00:00"^^xsd:dateTime ;
     skos:altLabel "Aussatz",
         "Aussätzige",
         "Bélpoklosság",
@@ -387,14 +387,14 @@ wd:Q36956 rdfs:label "Abïl",
     p:P902 <http://www.wikidata.org/entity/statement/Q36956-227BA989-0DB8-4851-9FA9-8D0B9A5C2CCC> ;
     p:P910 <http://www.wikidata.org/entity/statement/Q36956-3CA8A7C7-D284-43C0-BF0F-FE7F4C5D4D1D> ;
     p:P935 <http://www.wikidata.org/entity/statement/Q36956-FC3919F8-A2D9-4660-AD53-A3E555AAEF18> ;
-    ns2:P1256 <http://iconclass.org/31A4622> ;
-    ns2:P227 <http://d-nb.info/gnd/4035392-8> ;
-    ns2:P2581 <http://babelnet.org/rdf/s00042889n> ;
-    ns2:P349 <http://id.ndl.go.jp/auth/ndlna/00569249> ;
-    ns2:P486 <http://id.nlm.nih.gov/mesh/D007918> ;
-    ns2:P508 <http://purl.org/bncf/tid/14932> ;
-    ns2:P646 <http://g.co/kg/m/0c5f7> ;
-    ns2:P672 <https://id.nlm.nih.gov/mesh/C01.252.410.040.552.386> ;
+    ns1:P1256 <http://iconclass.org/31A4622> ;
+    ns1:P227 <http://d-nb.info/gnd/4035392-8> ;
+    ns1:P2581 <http://babelnet.org/rdf/s00042889n> ;
+    ns1:P349 <http://id.ndl.go.jp/auth/ndlna/00569249> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D007918> ;
+    ns1:P508 <http://purl.org/bncf/tid/14932> ;
+    ns1:P646 <http://g.co/kg/m/0c5f7> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C01.252.410.040.552.386> ;
     wdt:P1051 "12585" ;
     wdt:P1060 wd:Q15304512 ;
     wdt:P1193 1.0,
@@ -496,6 +496,9 @@ wd:Q36956 rdfs:label "Abïl",
 
 <http://www.wikidata.org/entity/statement/Q36956-1D3F6BDB-83D6-48A7-BE2D-CAD8BDF89494> prov:wasDerivedFrom <http://www.wikidata.org/reference/557ea321a4d4a5ee6ffff781bbbdd07ce0a5f12b> ;
     ps:P279 wd:Q3041498 .
+
+<http://www.wikidata.org/entity/statement/Q36956-1E2367F1-AFF6-4C84-A142-D59EA2C6006A> prov:wasDerivedFrom <http://www.wikidata.org/reference/557ea321a4d4a5ee6ffff781bbbdd07ce0a5f12b> ;
+    ps:P279 wd:Q18556979 .
 
 <http://www.wikidata.org/entity/statement/Q36956-2583C4D4-43BC-4CCB-9D54-4D5C06E276A3> prov:wasDerivedFrom <http://www.wikidata.org/reference/557ea321a4d4a5ee6ffff781bbbdd07ce0a5f12b> ;
     ps:P1550 "548" .

--- a/tests/test_issues/data/wikidata/disease/Q49989.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q49989.ttl
@@ -1,8 +1,8 @@
 @prefix do: <http://purl.obolibrary.org/obo/DOID_> .
 @prefix doio: <http://identifiers.org/doid/> .
 @prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
-@prefix ns1: <http://wikiba.se/ontology#> .
-@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
 @prefix p: <http://www.wikidata.org/prop/> .
 @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr: <http://www.wikidata.org/prop/reference/> .
@@ -71,10 +71,10 @@ wd:Q49989 rdfs:label "Boala Creutzfeldt-Jacob",
         "Наиболее распространенная прионная болезнь",
         "退行性神經系統疾病" ;
     schema:version 851698859 ;
-    ns1:identifiers 25 ;
-    ns1:sitelinks 45 ;
-    ns1:statements 41 ;
-    ns1:timestamp "2019-02-05T20:46:37+00:00"^^xsd:dateTime ;
+    ns2:identifiers 25 ;
+    ns2:sitelinks 45 ;
+    ns2:statements 41 ;
+    ns2:timestamp "2019-02-05T20:46:37+00:00"^^xsd:dateTime ;
     skos:altLabel "CJD",
         "CJD (Creutzfeldt Jakob disease)",
         "CJK",
@@ -131,11 +131,11 @@ wd:Q49989 rdfs:label "Boala Creutzfeldt-Jacob",
     p:P673 <http://www.wikidata.org/entity/statement/q49989-E83E1327-5C13-4B3F-BB49-1DF65926A1EA> ;
     p:P699 <http://www.wikidata.org/entity/statement/Q49989-161C34D8-88A3-4C6C-A153-02ED13E38DCF>,
         <http://www.wikidata.org/entity/statement/Q49989-DD691227-8D8E-4836-8D6A-3FCDECAB8F62> ;
-    ns2:P349 <http://id.ndl.go.jp/auth/ndlna/00575235> ;
-    ns2:P486 <http://id.nlm.nih.gov/mesh/D007562> ;
-    ns2:P508 <http://purl.org/bncf/tid/54342> ;
-    ns2:P646 <http://g.co/kg/m/01ptn> ;
-    ns2:P672 <https://id.nlm.nih.gov/mesh/C10.228.140.380.165>,
+    ns1:P349 <http://id.ndl.go.jp/auth/ndlna/00575235> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D007562> ;
+    ns1:P508 <http://purl.org/bncf/tid/54342> ;
+    ns1:P646 <http://g.co/kg/m/01ptn> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C10.228.140.380.165>,
         <https://id.nlm.nih.gov/mesh/C10.228.228.800.230> ;
     wdt:P1296 "0262750" ;
     wdt:P138 wd:Q62474,

--- a/tests/test_issues/data/wikidata/disease/Q819207.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q819207.ttl
@@ -1,0 +1,175 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q819207 rdfs:label "Pseudohipoparatireoidizam",
+        "Pseudohypoparathyreoidismus",
+        "pseudohipoparatiroidismo",
+        "pseudohypoparathyroidism",
+        "pseudohypoparathyroïdie",
+        "pseŭdohipoparatiroidismo",
+        "rzekoma niedoczynność przytarczyc",
+        "قصور جارات الدرق الكاذب",
+        "کم‌کاری کاذب غده پاراتیروئید",
+        "偽性副甲状腺機能低下症",
+        "거짓부갑상샘저하증" ;
+    schema:dateModified "2019-03-05T00:26:18+00:00"^^xsd:dateTime ;
+    schema:description "Krankheit",
+        "human disease",
+        "مرض يصيب الإنسان" ;
+    schema:version 874554328 ;
+    ns2:identifiers 28 ;
+    ns2:sitelinks 10 ;
+    ns2:statements 41 ;
+    ns2:timestamp "2019-03-05T00:26:22+00:00"^^xsd:dateTime ;
+    skos:altLabel "osteodystrofia Albrighta",
+        "zespół Albrighta",
+        "가부갑상선기능저하증",
+        "가성 부갑상샘 기능저하증",
+        "가성부갑상선기능저하증" ;
+    p:P1550 <http://www.wikidata.org/entity/statement/Q819207-4A5E4AA6-3023-4C31-83C5-7B7B66AB2E95> ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q819207-ED3E4D6F-F7C5-46F5-8CD8-7A513A90916F> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q819207-91A3A6DC-7A16-4A09-B52B-9CB847325AB1>,
+        <http://www.wikidata.org/entity/statement/Q819207-9757B62D-3B29-4B8A-B123-7283C62554CE> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q819207-EB527D6F-26FC-40AE-BBDB-A402D1B72B04> ;
+    p:P2581 <http://www.wikidata.org/entity/statement/Q819207-4E9FE2E3-7152-479A-9AE7-567CE7848DED> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q819207-9EEE1921-01F9-444E-8EF5-283DEED4C697>,
+        <http://www.wikidata.org/entity/statement/Q819207-9fe37e62-4f12-8a9b-3c19-cf592802bd1d> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q819207-3E57D264-B7AB-45F0-ACB2-0B8C8D7F5A45>,
+        <http://www.wikidata.org/entity/statement/Q819207-48FD9682-A44B-46CF-A548-04A9ECBAA53A>,
+        <http://www.wikidata.org/entity/statement/Q819207-B8BC56CF-33DA-42FD-BB1F-E8B162A9CC10>,
+        <http://www.wikidata.org/entity/statement/Q819207-F50552A3-F2A8-4B3A-9D5F-E41A6AD3E3D6> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q819207-49B64BA6-375E-4A58-913A-2E1AAA96CE07>,
+        <http://www.wikidata.org/entity/statement/Q819207-FEC8FA8D-F2D3-484D-8F3E-505E5EFC9EAC> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q819207-117C222E-9C7D-4202-9B7B-9ECEB2DD6A6D>,
+        <http://www.wikidata.org/entity/statement/Q819207-AD604960-5C2F-4CAA-9313-CFBCEEB2E07F> ;
+    p:P373 <http://www.wikidata.org/entity/statement/Q819207-7F07AC48-7899-44C4-BA20-BEB9734DC3EF> ;
+    p:P3827 <http://www.wikidata.org/entity/statement/Q819207-FB2737BA-A16D-43E4-BF2A-243B99269AA3> ;
+    p:P3841 <http://www.wikidata.org/entity/statement/Q819207-0EC096D4-2F09-4417-AE6B-1416CB072FC9> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q819207-F9E4A026-DB19-4147-BB74-FDC46A027B8E> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q819207-865E7AD3-683E-4A07-90AC-29EEC4C3A56B> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q819207-7C87D451-A74D-4AA0-9D41-1A7336562C33>,
+        <http://www.wikidata.org/entity/statement/Q819207-C290DBCC-E289-4C1B-9D4E-82642F814288> ;
+    p:P492 <http://www.wikidata.org/entity/statement/Q819207-8C4B7B9A-AAF8-43C2-9758-9B4699A48258>,
+        <http://www.wikidata.org/entity/statement/Q819207-96658D1B-FAB5-43F2-AC73-ABC12DFD03C4>,
+        <http://www.wikidata.org/entity/statement/Q819207-EF872336-5C4D-4395-BBAA-125DED08DEC9>,
+        <http://www.wikidata.org/entity/statement/q819207-A50B7BAD-B656-4CF9-A165-88C6FF64CDDE> ;
+    p:P493 <http://www.wikidata.org/entity/statement/q819207-295AABE5-4564-436C-BDEE-35BDD7E70DEC> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q819207-2F97B9AE-ADAA-4827-91AE-1D2E4BCB849D> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q819207-05589193-3611-48DD-B980-D5D75BB62803>,
+        <http://www.wikidata.org/entity/statement/q819207-83D0B41A-193E-4C11-80D6-EF3716C2AA12> ;
+    p:P604 <http://www.wikidata.org/entity/statement/q819207-17588CD3-3D37-42AE-A2AC-7DC087726549> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q819207-685DF057-6BA8-4DC0-8246-D8B58996CEA0> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q819207-51186877-F094-4D18-B703-9477B3AC990B>,
+        <http://www.wikidata.org/entity/statement/Q819207-7551D165-CAEB-4866-89BE-D79F6E2E5B36>,
+        <http://www.wikidata.org/entity/statement/Q819207-A2B0EB17-7BFC-4E4B-8ABC-3CC692E8A78A>,
+        <http://www.wikidata.org/entity/statement/Q819207-C2AEF386-A484-4554-AE19-0E0BD6B97F80>,
+        <http://www.wikidata.org/entity/statement/Q819207-CBC74BED-E6D8-4699-810F-04EE4A34DB96> ;
+    p:P673 <http://www.wikidata.org/entity/statement/q819207-58088334-D525-48D1-B7A1-A64AE46D9ECB> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q819207-38D931FC-5910-495D-9312-FC2C49DD2F9F>,
+        <http://www.wikidata.org/entity/statement/Q819207-A962A6EE-54BA-4126-98FB-5F0528A07EFD> ;
+    ns1:P2581 <http://babelnet.org/rdf/s02883542n> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D011547> ;
+    ns1:P646 <http://g.co/kg/m/09k1w5> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C05.116.198.709>,
+        <https://id.nlm.nih.gov/mesh/C16.320.565.618.815>,
+        <https://id.nlm.nih.gov/mesh/C18.452.104.709>,
+        <https://id.nlm.nih.gov/mesh/C18.452.174.766>,
+        <https://id.nlm.nih.gov/mesh/C18.452.648.618.815> ;
+    wdt:P1550 "97593" ;
+    wdt:P1692 "275.49" ;
+    wdt:P1748 "C99027" ;
+    wdt:P1995 wd:Q162606 ;
+    wdt:P2581 "02883542n" ;
+    wdt:P279 wd:Q3281373,
+        wd:Q55785986 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:4184>,
+        <http://purl.obolibrary.org/obo/DOID_4184>,
+        <http://purl.obolibrary.org/obo/HP_0000852>,
+        <http://www.orpha.net/ORDO/Orphanet_97593> ;
+    wdt:P2892 "C0033806" ;
+    wdt:P31 wd:Q12136,
+        wd:Q42303753 ;
+    wdt:P373 "Pseudohypoparathyroidism" ;
+    wdt:P3827 "pseudohypoparathyroidism" ;
+    wdt:P3841 "HP:0000852" ;
+    wdt:P4229 "E20.1" ;
+    wdt:P4317 "10758" ;
+    wdt:P486 "D011547" ;
+    wdt:P492 "603233",
+        "612462" ;
+    wdt:P493 "275.49" ;
+    wdt:P5270 "MONDO:0019992" ;
+    wdt:P557 "10835",
+        "10851" ;
+    wdt:P604 "000364" ;
+    wdt:P646 "/m/09k1w5" ;
+    wdt:P672 "C05.116.198.709",
+        "C16.320.565.618.815",
+        "C18.452.104.709",
+        "C18.452.174.766",
+        "C18.452.648.618.815" ;
+    wdt:P673 "124836" ;
+    wdt:P699 "DOID:4184" .
+
+<http://www.wikidata.org/entity/statement/Q819207-117C222E-9C7D-4202-9B7B-9ECEB2DD6A6D> prov:wasDerivedFrom <http://www.wikidata.org/reference/8d37730ae1c306781ba3091c8be5885fa54756c5> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q819207-38D931FC-5910-495D-9312-FC2C49DD2F9F> prov:wasDerivedFrom <http://www.wikidata.org/reference/0cecce68a7e524b4ecd809e0a7153ecde71d334b> ;
+    ps:P699 "DOID:4184" .
+
+<http://www.wikidata.org/entity/statement/Q819207-49B64BA6-375E-4A58-913A-2E1AAA96CE07> prov:wasDerivedFrom <http://www.wikidata.org/reference/0cecce68a7e524b4ecd809e0a7153ecde71d334b>,
+        <http://www.wikidata.org/reference/3a5b26dc1c88b4bac1eea084f09325be4d075787> ;
+    ps:P2892 "C0033806" .
+
+<http://www.wikidata.org/entity/statement/Q819207-4A5E4AA6-3023-4C31-83C5-7B7B66AB2E95> prov:wasDerivedFrom <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    ps:P1550 "97593" .
+
+<http://www.wikidata.org/entity/statement/Q819207-7C87D451-A74D-4AA0-9D41-1A7336562C33> prov:wasDerivedFrom <http://www.wikidata.org/reference/0cecce68a7e524b4ecd809e0a7153ecde71d334b>,
+        <http://www.wikidata.org/reference/3a5b26dc1c88b4bac1eea084f09325be4d075787> ;
+    ps:P486 "D011547" .
+
+<http://www.wikidata.org/entity/statement/Q819207-91A3A6DC-7A16-4A09-B52B-9CB847325AB1> prov:wasDerivedFrom <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    ps:P1748 "C99027" .
+
+<http://www.wikidata.org/entity/statement/Q819207-9757B62D-3B29-4B8A-B123-7283C62554CE> prov:wasDerivedFrom <http://www.wikidata.org/reference/0cecce68a7e524b4ecd809e0a7153ecde71d334b> ;
+    ps:P1748 "C99027" .
+
+<http://www.wikidata.org/entity/statement/Q819207-9fe37e62-4f12-8a9b-3c19-cf592802bd1d> ps:P279 wd:Q55785986 .
+
+<http://www.wikidata.org/entity/statement/Q819207-A962A6EE-54BA-4126-98FB-5F0528A07EFD> prov:wasDerivedFrom <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    ps:P699 "DOID:4184" .
+
+<http://www.wikidata.org/entity/statement/Q819207-AD604960-5C2F-4CAA-9313-CFBCEEB2E07F> prov:wasDerivedFrom <http://www.wikidata.org/reference/ce46ad015e3a19d5d4bcac44e0d6acb173581886> ;
+    ps:P31 wd:Q42303753 .
+
+<http://www.wikidata.org/entity/statement/Q819207-C290DBCC-E289-4C1B-9D4E-82642F814288> prov:wasDerivedFrom <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P486 "D011547" .
+
+<http://www.wikidata.org/entity/statement/Q819207-F9E4A026-DB19-4147-BB74-FDC46A027B8E> prov:wasDerivedFrom <http://www.wikidata.org/reference/0cecce68a7e524b4ecd809e0a7153ecde71d334b>,
+        <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    ps:P4229 "E20.1" .
+
+<http://www.wikidata.org/entity/statement/Q819207-FEC8FA8D-F2D3-484D-8F3E-505E5EFC9EAC> prov:wasDerivedFrom <http://www.wikidata.org/reference/a1a9b6675ca321a6b696aaf9a8e4cd43f3390942> ;
+    ps:P2892 "C0033806" .
+
+<http://www.wikidata.org/entity/statement/q819207-295AABE5-4564-436C-BDEE-35BDD7E70DEC> prov:wasDerivedFrom <http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1> ;
+    ps:P493 "275.49" .
+

--- a/tests/test_issues/data/wikidata/disease/Q8285.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q8285.ttl
@@ -1,8 +1,8 @@
 @prefix do: <http://purl.obolibrary.org/obo/DOID_> .
 @prefix doio: <http://identifiers.org/doid/> .
 @prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
-@prefix ns1: <http://wikiba.se/ontology#> .
-@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
 @prefix p: <http://www.wikidata.org/prop/> .
 @prefix pq: <http://www.wikidata.org/prop/qualifier/> .
 @prefix pr: <http://www.wikidata.org/prop/reference/> .
@@ -70,10 +70,10 @@ wd:Q8285 rdfs:label "Bệnh nhược cơ",
         "ଦୀର୍ଘକାଳୀନ ସ୍ନାୟୁ-ମାଂସପେଶୀ ରୋଗ",
         "アセチルコリンなどの抗体により神経・筋伝達が阻害されるために筋肉の易疲労性や脱力が起こる自己免疫疾患" ;
     schema:version 823738857 ;
-    ns1:identifiers 35 ;
-    ns1:sitelinks 54 ;
-    ns1:statements 69 ;
-    ns1:timestamp "2018-12-31T08:02:44+00:00"^^xsd:dateTime ;
+    ns2:identifiers 35 ;
+    ns2:sitelinks 54 ;
+    ns2:statements 69 ;
+    ns2:timestamp "2018-12-31T08:02:44+00:00"^^xsd:dateTime ;
     skos:altLabel "Acquired myasthenia",
         "Astenik Bulbar Falaj",
         "Astenik bulbar falaj",
@@ -157,11 +157,11 @@ wd:Q8285 rdfs:label "Bệnh nhược cơ",
     p:P699 <http://www.wikidata.org/entity/statement/Q8285-7735179B-C005-47F4-A19B-4CA0C081968A>,
         <http://www.wikidata.org/entity/statement/Q8285-ECFD96DB-F159-496A-AF2B-D52B1EABF2A0> ;
     p:P910 <http://www.wikidata.org/entity/statement/Q8285-42587E5C-70AD-4FDF-9849-2C179C338A68> ;
-    ns2:P227 <http://d-nb.info/gnd/4075144-2> ;
-    ns2:P486 <http://id.nlm.nih.gov/mesh/D009157> ;
-    ns2:P508 <http://purl.org/bncf/tid/46655> ;
-    ns2:P646 <http://g.co/kg/m/04st8> ;
-    ns2:P672 <https://id.nlm.nih.gov/mesh/C10.114.656>,
+    ns1:P227 <http://d-nb.info/gnd/4075144-2> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D009157> ;
+    ns1:P508 <http://purl.org/bncf/tid/46655> ;
+    ns1:P646 <http://g.co/kg/m/04st8> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C10.114.656>,
         <https://id.nlm.nih.gov/mesh/C10.668.758.725>,
         <https://id.nlm.nih.gov/mesh/C20.111.258.500> ;
     wdt:P1417 "science/myasthenia-gravis" ;

--- a/tests/test_issues/data/wikidata/disease/Q829150.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q829150.ttl
@@ -1,0 +1,144 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://wikiba.se/ontology#> .
+@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q829150 rdfs:label "Choroba Andersen",
+        "Morbus Andersen",
+        "enfermedad de Andersen",
+        "glycogen storage disease IV",
+        "glycogénose type 4",
+        "malaltia d'Andersen",
+        "malattia da deposito di glicogeno, tipo 4",
+        "Болезнь Андерсена",
+        "Хвороба Андерсен",
+        "گلیکوژنوز نوع چهار" ;
+    schema:dateModified "2019-03-05T00:15:35+00:00"^^xsd:dateTime ;
+    schema:description "Krankheit",
+        "human disease",
+        "malattia genetica",
+        "مرض يصيب الإنسان" ;
+    schema:version 874547910 ;
+    ns1:identifiers 15 ;
+    ns1:sitelinks 10 ;
+    ns1:statements 27 ;
+    ns1:timestamp "2019-03-05T00:29:53+00:00"^^xsd:dateTime ;
+    skos:altLabel "Amylopectinosis",
+        "Amylopektinose",
+        "Amylopektynoza",
+        "Andersen-Glykogenose",
+        "Andersen-Krankheit",
+        "Andersen-Syndrom",
+        "Branching-transferase deficiency glycogenosis",
+        "Branching-transferase deficiency glycogenosis (disorder)",
+        "Choroba Andersena",
+        "GSD IV",
+        "Glikogenoza typu IV",
+        "Glycogen storage disease, type IV",
+        "Glycogen storage disease, type IV (disorder)",
+        "Glykogenose Typ IV",
+        "Maladie d'Andersen",
+        "brancher deficiency glycogenosis",
+        "deficiency of 1,4-alpha-glucan branching enzyme",
+        "glucogenosis tipo IV" ;
+    p:P1296 <http://www.wikidata.org/entity/statement/Q829150-50D2AD96-BAD7-4D45-96C8-F9D0ED702B41> ;
+    p:P138 <http://www.wikidata.org/entity/statement/Q829150-aba050da-44c4-fdd1-88aa-d9b9099d12a1> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q829150-6BEDEEA2-965C-4A79-83C2-729E96F84C65> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q829150-1a827b69-4c22-04ad-e908-40786b57e550>,
+        <http://www.wikidata.org/entity/statement/Q829150-3957A94E-0516-40A1-A780-18FC2AAF08FA>,
+        <http://www.wikidata.org/entity/statement/Q829150-543dc381-4a71-1620-9634-3979d5d8d979> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q829150-e3b57fa5-4886-0d48-e0a5-87386150dbc8> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q829150-E638C36B-97DC-4733-B1F2-30B2A8D1368C>,
+        <http://www.wikidata.org/entity/statement/Q829150-E8352FEC-166C-4CB5-9769-7A3C4A23A408> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q829150-5CCCA495-07DC-476C-BFC3-5E7D664CFDDB> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q829150-8C9E68BF-65C9-4B03-A681-984316224CA9> ;
+    p:P3219 <http://www.wikidata.org/entity/statement/Q829150-B073BF44-9D0C-420E-A915-1459E41EEDB0> ;
+    p:P3720 <http://www.wikidata.org/entity/statement/Q829150-3F59DEE4-C502-4DE6-A5FD-5B758E35A734> ;
+    p:P373 <http://www.wikidata.org/entity/statement/Q829150-8bf0d681-44c9-532a-ce12-d0b68d1be239> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q829150-CAC26E05-EDCB-41CB-A998-242C39881E25> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q829150-B36F139A-FC51-4D83-A529-FA71284200EE> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q829150-C450EDCE-9F93-4DE2-9D69-DD4E30DF825D> ;
+    p:P492 <http://www.wikidata.org/entity/statement/q829150-729E25E0-3FB9-4335-9405-D59B3F5B8A11> ;
+    p:P493 <http://www.wikidata.org/entity/statement/q829150-2E511164-6FA3-4C9E-B634-9DD5E56E4E72> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q829150-2AF91C9C-DC2C-4849-9974-AF15486B6440> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q829150-2EE842E7-E618-40D7-A76D-86A86518FABC> ;
+    p:P667 <http://www.wikidata.org/entity/statement/Q829150-B48A704A-45D9-4606-BB9B-ADCAE461B340> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q829150-97CA9910-96F6-47FB-815A-52121D29CEF3>,
+        <http://www.wikidata.org/entity/statement/Q829150-BE4977B0-9376-44AE-B506-7B33233BACD9> ;
+    p:P673 <http://www.wikidata.org/entity/statement/q829150-1B679C17-811D-4168-8E04-248B711693F1> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q829150-A11DCBC4-7C9F-4316-980D-699FC037394E> ;
+    p:P828 <http://www.wikidata.org/entity/statement/Q829150-3fb429ef-44cd-5c9d-0dc7-ee1e5e230ec3> ;
+    ns2:P486 <http://id.nlm.nih.gov/mesh/D006011> ;
+    ns2:P646 <http://g.co/kg/m/08h3t_> ;
+    ns2:P672 <https://id.nlm.nih.gov/mesh/C16.320.565.202.449.540>,
+        <https://id.nlm.nih.gov/mesh/C18.452.648.202.449.540> ;
+    wdt:P1296 "0247152" ;
+    wdt:P138 wd:Q469231 ;
+    wdt:P1748 "C84737" ;
+    wdt:P1995 wd:Q1071953,
+        wd:Q162606,
+        wd:Q668064 ;
+    wdt:P279 wd:Q1421738 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:2750>,
+        <http://purl.obolibrary.org/obo/DOID_2750> ;
+    wdt:P2892 "C0017923" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3219 "maladie-d-andersen" ;
+    wdt:P3720 "697958448" ;
+    wdt:P373 "Glycogen storage disease type IV" ;
+    wdt:P4229 "E74.09" ;
+    wdt:P4317 "2520" ;
+    wdt:P486 "D006011" ;
+    wdt:P492 "232500" ;
+    wdt:P493 "271.0" ;
+    wdt:P557 "5303" ;
+    wdt:P646 "/m/08h3t_" ;
+    wdt:P667 "T99" ;
+    wdt:P672 "C16.320.565.202.449.540",
+        "C18.452.648.202.449.540" ;
+    wdt:P673 "941632" ;
+    wdt:P699 "DOID:2750" ;
+    wdt:P828 wd:Q42918 .
+
+<http://www.wikidata.org/entity/statement/Q829150-5CCCA495-07DC-476C-BFC3-5E7D664CFDDB> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P2892 "C0017923" .
+
+<http://www.wikidata.org/entity/statement/Q829150-6BEDEEA2-965C-4A79-83C2-729E96F84C65> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P1748 "C84737" .
+
+<http://www.wikidata.org/entity/statement/Q829150-8C9E68BF-65C9-4B03-A681-984316224CA9> prov:wasDerivedFrom <http://www.wikidata.org/reference/dd9a62c043aace390ef55e03b1e703b4812f3c54> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q829150-A11DCBC4-7C9F-4316-980D-699FC037394E> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P699 "DOID:2750" .
+
+<http://www.wikidata.org/entity/statement/Q829150-C450EDCE-9F93-4DE2-9D69-DD4E30DF825D> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P486 "D006011" .
+
+<http://www.wikidata.org/entity/statement/Q829150-CAC26E05-EDCB-41CB-A998-242C39881E25> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P4229 "E74.09" .
+
+<http://www.wikidata.org/entity/statement/Q829150-e3b57fa5-4886-0d48-e0a5-87386150dbc8> prov:wasDerivedFrom <http://www.wikidata.org/reference/dd9a62c043aace390ef55e03b1e703b4812f3c54> ;
+    ps:P279 wd:Q1421738 .
+
+<http://www.wikidata.org/entity/statement/q829150-2E511164-6FA3-4C9E-B634-9DD5E56E4E72> prov:wasDerivedFrom <http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1> ;
+    ps:P493 "271.0" .
+
+<http://www.wikidata.org/entity/statement/q829150-729E25E0-3FB9-4335-9405-D59B3F5B8A11> prov:wasDerivedFrom <http://www.wikidata.org/reference/3602037d0792b65f25a17eedab83ef2e3330664f> ;
+    ps:P492 "232500" .
+

--- a/tests/test_issues/data/wikidata/disease/Q842169.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q842169.ttl
@@ -1,0 +1,174 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q842169 rdfs:label "Sparganose",
+        "esparganosis",
+        "sparganose",
+        "sparganosis",
+        "Спарганоз",
+        "داء المكفنات",
+        "孤虫症",
+        "裂頭絛蟲症",
+        "스파르가눔증" ;
+    schema:dateModified "2019-03-05T01:48:22+00:00"^^xsd:dateTime ;
+    schema:description "Helminthiasis",
+        "Parasitose durch das Sparganum von Spirometra erinaceieuropaei",
+        "parasitose",
+        "гельмінтоз з групи цестодозів" ;
+    schema:version 874597649 ;
+    ns2:identifiers 13 ;
+    ns2:sitelinks 8 ;
+    ns2:statements 36 ;
+    ns2:timestamp "2019-03-05T01:48:24+00:00"^^xsd:dateTime ;
+    skos:altLabel "Infection by Sparganum",
+        "Sparganosis",
+        "Sparganosis [larval diphyllobothriasis]",
+        "스파르가눔" ;
+    p:P1060 <http://www.wikidata.org/entity/statement/Q842169-85773d0b-47e2-906e-9287-4f5d50886589>,
+        <http://www.wikidata.org/entity/statement/Q842169-facb8db0-4508-b146-984c-bd500f128503> ;
+    p:P1417 <http://www.wikidata.org/entity/statement/Q842169-5250465C-B79E-46BA-A6C3-F46B682D7131> ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q842169-FEDAA431-BBAA-4F40-80F0-6B5C9F84C87A> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q842169-056B23F0-5505-4EC0-87B2-5F477AAD8763>,
+        <http://www.wikidata.org/entity/statement/Q842169-B2CBB222-0BFF-4057-8C9F-56C9DDA19582> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q842169-95BF9ED4-E110-4190-9EF8-4D8BDB0E2DAC> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q842169-01BF910E-B192-4CE0-A2A5-6EE410187B9E>,
+        <http://www.wikidata.org/entity/statement/Q842169-179EA7E9-3EC8-40E6-B191-C398E3E54AC2>,
+        <http://www.wikidata.org/entity/statement/Q842169-2EBAD511-F0E1-4E86-8DDA-8F751AAC79E9>,
+        <http://www.wikidata.org/entity/statement/Q842169-6F9304CD-0744-4522-BB53-E1E125EDACB7>,
+        <http://www.wikidata.org/entity/statement/Q842169-7711c1c9-44e1-a00a-1d45-026f08de7d0e>,
+        <http://www.wikidata.org/entity/statement/Q842169-930A0100-EA29-4DAD-903A-35E9761974CA>,
+        <http://www.wikidata.org/entity/statement/Q842169-cfde7332-4399-6a56-96f0-f129cd325972> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q842169-EC399A82-1DED-49D1-B72F-3CBD1DDA2CD8>,
+        <http://www.wikidata.org/entity/statement/Q842169-F158004C-13D0-4AB6-82D8-36F568E6FB42> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q842169-4649C5F7-97FA-4676-B7A3-6C80D318C101>,
+        <http://www.wikidata.org/entity/statement/Q842169-DF8F8A54-4A03-418C-9E34-BA0F315F77D0> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q842169-B9540076-F310-4EAD-B680-22E0160EF6A3>,
+        <http://www.wikidata.org/entity/statement/Q842169-DE329577-9AFD-458A-AF04-229A72BE75C3>,
+        <http://www.wikidata.org/entity/statement/Q842169-E23CA109-FB6C-4B3F-AAF3-72378DF03FB3> ;
+    p:P3827 <http://www.wikidata.org/entity/statement/Q842169-D322DBDC-2F2B-4176-9D43-031918443160> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q842169-40BDD4F2-A0F5-46B1-8999-A46F2D403C6E> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q842169-0D455210-51EB-4E42-83E1-601A8C4F5D76>,
+        <http://www.wikidata.org/entity/statement/Q842169-10B51329-693E-44FF-85AE-0A355E15FD96> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q842169-9E7983EE-5EA4-4521-8DEF-8937076FBD31> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q842169-D031C5AE-9255-4AB5-87BD-57660EAB4BF4> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q842169-2DC77259-7425-4C75-BD75-8B61B7B4BE77> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q842169-222BE5F6-03C9-4CE9-BF0D-FB91D3FB0723> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q842169-BE830647-FF8A-4603-B981-BFE0CF1750D6>,
+        <http://www.wikidata.org/entity/statement/Q842169-F1CEB65B-2A82-4764-B57C-E295AE9B44BE> ;
+    p:P828 <http://www.wikidata.org/entity/statement/Q842169-7e8721dd-4899-448b-aaa7-33cf05295c14>,
+        <http://www.wikidata.org/entity/statement/Q842169-86f25c97-4187-6801-d4a5-c3d0ba104efe>,
+        <http://www.wikidata.org/entity/statement/Q842169-908683ca-452f-b53a-1367-6d2fdd158742> ;
+    p:P924 <http://www.wikidata.org/entity/statement/Q842169-73d8b202-4827-37b0-5d8f-faa869e2c622>,
+        <http://www.wikidata.org/entity/statement/Q842169-7429456c-4f90-e863-6f12-b7524d0ef4eb> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D013031> ;
+    ns1:P646 <http://g.co/kg/m/05c5zh8> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C03.335.190.304.780> ;
+    wdt:P1060 wd:Q15304512,
+        wd:Q2272069 ;
+    wdt:P1417 "science/sparganosis" ;
+    wdt:P1692 "123.5" ;
+    wdt:P1748 "C35030" ;
+    wdt:P1995 wd:Q788926 ;
+    wdt:P279 wd:Q182672,
+        wd:Q18555242,
+        wd:Q3392853,
+        wd:Q4505372,
+        wd:Q4959796,
+        wd:Q578994,
+        wd:Q7900883 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:10080>,
+        <http://purl.obolibrary.org/obo/DOID_10080> ;
+    wdt:P2892 "C0037753" ;
+    wdt:P31 wd:Q12136,
+        wd:Q18123741,
+        wd:Q2084422 ;
+    wdt:P3827 "sparganosis" ;
+    wdt:P4229 "B70.1" ;
+    wdt:P486 "D013031" ;
+    wdt:P5270 "MONDO:0005963" ;
+    wdt:P557 "32210" ;
+    wdt:P646 "/m/05c5zh8" ;
+    wdt:P672 "C03.335.190.304.780" ;
+    wdt:P699 "DOID:10080" ;
+    wdt:P828 wd:Q141837,
+        wd:Q166231,
+        wd:Q2307189 ;
+    wdt:P924 wd:Q424145,
+        wd:Q600236 .
+
+<http://www.wikidata.org/entity/statement/Q842169-01BF910E-B192-4CE0-A2A5-6EE410187B9E> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P279 wd:Q3392853 .
+
+<http://www.wikidata.org/entity/statement/Q842169-056B23F0-5505-4EC0-87B2-5F477AAD8763> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P1748 "C35030" .
+
+<http://www.wikidata.org/entity/statement/Q842169-0D455210-51EB-4E42-83E1-601A8C4F5D76> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P486 "D013031" .
+
+<http://www.wikidata.org/entity/statement/Q842169-10B51329-693E-44FF-85AE-0A355E15FD96> prov:wasDerivedFrom <http://www.wikidata.org/reference/50639a0efd9aaf18ad00d26d95d89e6f60400fb2>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P486 "D013031" .
+
+<http://www.wikidata.org/entity/statement/Q842169-179EA7E9-3EC8-40E6-B191-C398E3E54AC2> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P279 wd:Q4959796 .
+
+<http://www.wikidata.org/entity/statement/Q842169-2EBAD511-F0E1-4E86-8DDA-8F751AAC79E9> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P279 wd:Q18555242 .
+
+<http://www.wikidata.org/entity/statement/Q842169-40BDD4F2-A0F5-46B1-8999-A46F2D403C6E> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P4229 "B70.1" .
+
+<http://www.wikidata.org/entity/statement/Q842169-4649C5F7-97FA-4676-B7A3-6C80D318C101> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P2892 "C0037753" .
+
+<http://www.wikidata.org/entity/statement/Q842169-6F9304CD-0744-4522-BB53-E1E125EDACB7> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P279 wd:Q578994 .
+
+<http://www.wikidata.org/entity/statement/Q842169-7711c1c9-44e1-a00a-1d45-026f08de7d0e> ps:P279 wd:Q182672 .
+
+<http://www.wikidata.org/entity/statement/Q842169-930A0100-EA29-4DAD-903A-35E9761974CA> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P279 wd:Q7900883 .
+
+<http://www.wikidata.org/entity/statement/Q842169-B2CBB222-0BFF-4057-8C9F-56C9DDA19582> prov:wasDerivedFrom <http://www.wikidata.org/reference/50639a0efd9aaf18ad00d26d95d89e6f60400fb2>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P1748 "C35030" .
+
+<http://www.wikidata.org/entity/statement/Q842169-B9540076-F310-4EAD-B680-22E0160EF6A3> ps:P31 wd:Q2084422 .
+
+<http://www.wikidata.org/entity/statement/Q842169-BE830647-FF8A-4603-B981-BFE0CF1750D6> prov:wasDerivedFrom <http://www.wikidata.org/reference/50639a0efd9aaf18ad00d26d95d89e6f60400fb2>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P699 "DOID:10080" .
+
+<http://www.wikidata.org/entity/statement/Q842169-DE329577-9AFD-458A-AF04-229A72BE75C3> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q842169-DF8F8A54-4A03-418C-9E34-BA0F315F77D0> prov:wasDerivedFrom <http://www.wikidata.org/reference/50639a0efd9aaf18ad00d26d95d89e6f60400fb2>,
+        <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P2892 "C0037753" .
+
+<http://www.wikidata.org/entity/statement/Q842169-E23CA109-FB6C-4B3F-AAF3-72378DF03FB3> prov:wasDerivedFrom <http://www.wikidata.org/reference/afaed60e5dc47a37c7e8156e2151ca609d842ae1> ;
+    ps:P31 wd:Q18123741 .
+
+<http://www.wikidata.org/entity/statement/Q842169-F1CEB65B-2A82-4764-B57C-E295AE9B44BE> prov:wasDerivedFrom <http://www.wikidata.org/reference/8ad3ff36b42af0765d7384059df65763796461ea> ;
+    ps:P699 "DOID:10080" .
+

--- a/tests/test_issues/data/wikidata/disease/Q848371.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q848371.ttl
@@ -1,0 +1,131 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q848371 rdfs:label "Lichen planus",
+        "Lichen ruber planus",
+        "Liszaj płaski",
+        "Plakanā mezgliņēde",
+        "Punajäkälä",
+        "lichen plan",
+        "lichen planus",
+        "licher ruber",
+        "liquen pla",
+        "liquen plano",
+        "líquen plano",
+        "Кызыл жалпак чакалай",
+        "Плоский лишай",
+        "ילפת שטוחה",
+        "حزاز مسطح",
+        "لیکن پلان",
+        "لیکێن پلانوس",
+        "扁平苔癬",
+        "扁平苔藓" ;
+    schema:dateModified "2019-03-05T02:57:33+00:00"^^xsd:dateTime ;
+    schema:description "Krankheit",
+        "enfermedad inflamatoria poco común que afecta la piel y la mucosa oral",
+        "lichen disease that is located in skin, located in tongue or located in oral mucosa, which presents itself in the form of papules, lesions or rashes",
+        "lichen planus",
+        "maladie inflammatoire touchant la peau, la muqueuse de la bouche, ou parfois les deux",
+        "ילפת שטוחה",
+        "بیماری پوستی" ;
+    schema:version 874629648 ;
+    ns2:identifiers 19 ;
+    ns2:sitelinks 22 ;
+    ns2:statements 30 ;
+    ns2:timestamp "2019-03-05T02:57:34+00:00"^^xsd:dateTime ;
+    skos:altLabel "Flache Knötchenflechte",
+        "Knötchenflechte",
+        "Lichen",
+        "Lichen Planus",
+        "Lichen planus",
+        "Lichen planus (disorder)",
+        "Lichen planus NOS (disorder)",
+        "Lichen ruber planus",
+        "Lichen, ruber planus",
+        "Lichens plan",
+        "Liszaj czerwony",
+        "Lupus erythematosus–lichen planus overlap syndrome",
+        "Peno-gingival syndrome",
+        "lichen ruber planus",
+        "ruber planus",
+        "Червоний плоский лишай" ;
+    p:P1417 <http://www.wikidata.org/entity/statement/Q848371-4648099C-DB86-4A54-8C7E-718FA1D352EE> ;
+    p:P1461 <http://www.wikidata.org/entity/statement/Q848371-7DFD046B-902F-4FE2-A0B8-D9C3ED769DFD> ;
+    p:P1550 <http://www.wikidata.org/entity/statement/Q848371-B35145BA-2EF8-4CB7-83C7-E3CACC9E9311> ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q848371-8A3E2DC0-BFAB-4589-AA09-32178DA8CDD4> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q848371-6607D01F-8F80-4B40-9D52-FD2CC692C892>,
+        <http://www.wikidata.org/entity/statement/Q848371-7E835C0A-064C-4845-9724-7450DE87A1AB> ;
+    p:P18 <http://www.wikidata.org/entity/statement/Q848371-E941D3AC-E390-4F9D-A182-AFAA0A27C1D5> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q848371-4C91285A-FB73-4EE4-BEB5-052F540905D6> ;
+    p:P2176 <http://www.wikidata.org/entity/statement/Q848371-45B3C829-1CA0-4605-A25B-2B4B7E526EC9> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q848371-431C709A-BB67-4A6E-B457-060993151C88>,
+        <http://www.wikidata.org/entity/statement/Q848371-8C36E683-7FAC-49B1-B834-CB47B7C9C86C> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q848371-41E2B8FA-F367-48A9-B0BD-DECFCE25BF7B>,
+        <http://www.wikidata.org/entity/statement/Q848371-B04FC526-A5A3-4F8F-8E5E-2EDE81CE3729> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q848371-0BDB5750-0D66-4116-BC57-6EEB18EBC6BF> ;
+    p:P3471 <http://www.wikidata.org/entity/statement/Q848371-3C935F9A-C3C8-4A3D-BBBD-6BA2E332C910> ;
+    p:P373 <http://www.wikidata.org/entity/statement/q848371-1C65FAA3-0B55-4B87-9890-893EA1D9DA3D> ;
+    p:P3827 <http://www.wikidata.org/entity/statement/Q848371-F14C0B81-3668-484E-8086-DE9362D082F0> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q848371-9345B97A-5236-46CF-A681-EE2610FD8ABB>,
+        <http://www.wikidata.org/entity/statement/Q848371-A4DC4411-5821-4D01-AD3B-B44522631AC2> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q848371-B7061588-E4A2-40C5-AB54-753A750B5E14> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q848371-650ED250-61FF-4430-91F2-A33D6122F066>,
+        <http://www.wikidata.org/entity/statement/Q848371-9EBECBDF-5CFE-4F3E-80A6-48364512B924> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q848371-E6B8FD4D-AA26-46E8-AFFB-B850B31CFBD0> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q848371-471F6363-B8B6-45EC-9402-D41FB3A77BC2> ;
+    p:P604 <http://www.wikidata.org/entity/statement/q848371-89785E9E-4F2B-4AEF-B190-2D2F7BA62063> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q848371-4ACCF712-8778-406B-9D73-2077785B1C39> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q848371-09F5A1D3-90B7-4C16-873C-4E9C1E4DF610> ;
+    p:P673 <http://www.wikidata.org/entity/statement/q848371-EFF10D66-A6E4-4019-8C9A-CF52A540C004> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q848371-1BE98BB1-F80B-4C6A-8592-924F7B9F3D41>,
+        <http://www.wikidata.org/entity/statement/Q848371-B012A4BD-3E63-47D0-8E97-ED731AE69E02> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D008010> ;
+    ns1:P646 <http://g.co/kg/m/03nfsv> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C17.800.859.475.560> ;
+    wdt:P1417 "science/lichen-planus" ;
+    wdt:P1461 "lichen-planus-pro" ;
+    wdt:P1550 "254367" ;
+    wdt:P1692 "697.0" ;
+    wdt:P1748 "C3189" ;
+    wdt:P18 <http://commons.wikimedia.org/wiki/Special:FilePath/Lichen%20planus%20lip.jpg> ;
+    wdt:P1995 wd:Q171171 ;
+    wdt:P2176 wd:Q411648 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:9201>,
+        <http://purl.obolibrary.org/obo/DOID_9201> ;
+    wdt:P2892 "C0023646" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3471 "10342" ;
+    wdt:P373 "Lichen planus" ;
+    wdt:P3827 "lichen-planus" ;
+    wdt:P4229 "L43",
+        "L43.9" ;
+    wdt:P4317 "12344" ;
+    wdt:P486 "D008010" ;
+    wdt:P5270 "MONDO:0006572" ;
+    wdt:P557 "7452" ;
+    wdt:P604 "000867" ;
+    wdt:P646 "/m/03nfsv" ;
+    wdt:P672 "C17.800.859.475.560" ;
+    wdt:P673 "1123213" ;
+    wdt:P699 "DOID:9201" .
+
+<http://www.wikidata.org/entity/statement/Q848371-0BDB5750-0D66-4116-BC57-6EEB18EBC6BF> prov:wasDerivedFrom <http://www.wikidata.org/reference/9d398d3e77fa2e689497c9e654e838b473eec325> ;
+    ps:P31 wd:Q12136 .
+

--- a/tests/test_issues/data/wikidata/disease/Q860395.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q860395.ttl
@@ -1,0 +1,185 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://wikiba.se/ontology#> .
+@prefix ns2: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q860395 rdfs:label "Oistéamalaice",
+        "Osteomalacia",
+        "Osteomalacie",
+        "Osteomalacija",
+        "Osteomalacja",
+        "Osteomalasia",
+        "Osteomalazi",
+        "Osteomalazie",
+        "Osteomaliacija",
+        "Osteomalyacïya",
+        "benvävsuppmjukning",
+        "osteomalacia",
+        "osteomalacie",
+        "osteomalasi",
+        "osteomalazia",
+        "osteomalàcia",
+        "ostéomalacie",
+        "Остеомаляция",
+        "Остеомаляція",
+        "Ոսկրակակղանք",
+        "تلين العظام",
+        "نرم‌استخوانی",
+        "نەرمیی ئێسک",
+        "وستەومالياتسىييا",
+        "अस्थिमृदुता",
+        "軟骨病",
+        "骨軟化症",
+        "골연화증" ;
+    schema:dateModified "2019-03-05T01:50:23+00:00"^^xsd:dateTime ;
+    schema:description "Deskaltzifikazioa eta odoleko kaltzio- eta fosforo-kontzentrazioa gutxiagotzea ezaugarritzat dituen gaixotasuna. D bitamina hartuz sendatzen da",
+        "Krankheit",
+        "bone remodeling disease that has material basis in a vitamin D deficiency which results in softening located in bone",
+        "choroba" ;
+    schema:version 874598686 ;
+    ns1:identifiers 22 ;
+    ns1:sitelinks 30 ;
+    ns1:statements 35 ;
+    ns1:timestamp "2019-03-05T01:50:24+00:00"^^xsd:dateTime ;
+    skos:altLabel "Esmolecemento",
+        "Looser-Umbauzone",
+        "Looser-Zone",
+        "Osteomalaci",
+        "Osteomalacie",
+        "Osteomalácia",
+        "Raquitismo",
+        "osteomalacia",
+        "remolliment dels ossos",
+        "استئومالاسی",
+        "تلين العظم",
+        "لين العظام",
+        "لين العظم",
+        "لين عظام",
+        "نرم استخوانی",
+        "ओस्टीयोमलेशिया",
+        "뼈연화증" ;
+    p:P1343 <http://www.wikidata.org/entity/statement/Q860395-1AED107D-3F69-4160-8446-0FFF0C47C063> ;
+    p:P1417 <http://www.wikidata.org/entity/statement/Q860395-4DDB9724-0B3F-4329-AE52-DD2C53685FC8> ;
+    p:P1461 <http://www.wikidata.org/entity/statement/Q860395-D7FE3AC0-98C1-4F32-9D64-930480BE520D> ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q860395-604521EE-3521-41F3-95B9-95DBDF79BDE0> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q860395-3C0167EB-283E-4E32-BA3F-57AFB5992C88>,
+        <http://www.wikidata.org/entity/statement/Q860395-B6BA04B3-8E0C-4258-9EF6-FAF5120C9112> ;
+    p:P18 <http://www.wikidata.org/entity/statement/Q860395-e673dba9-46c5-9cc4-05a5-9da39ed5e9c5> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q860395-C43A8C2E-83DB-40CD-8AAF-3AC888173335> ;
+    p:P2176 <http://www.wikidata.org/entity/statement/Q860395-B27030D8-9F78-4A72-BBBE-986520D32FBB> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q860395-9FE199CE-6A82-4EC9-8B67-52C8A67BD66D> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q860395-55A79EA2-3890-491D-832F-C5D249F8565F>,
+        <http://www.wikidata.org/entity/statement/Q860395-56F9DC3D-0567-4B76-AA02-613418BAF225>,
+        <http://www.wikidata.org/entity/statement/Q860395-E4826842-3922-4E7D-B826-306E88EC2C58> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q860395-43CAB09C-8C77-41C7-B159-B3D96E6FE96B>,
+        <http://www.wikidata.org/entity/statement/Q860395-582BD7A3-2FA2-452D-8882-4C668851C997> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q860395-C2F5365F-9E86-4F9E-84D0-C72290A0EDDD> ;
+    p:P3827 <http://www.wikidata.org/entity/statement/Q860395-0807FD61-F31B-4BD7-95F5-D6883118C4B1> ;
+    p:P3841 <http://www.wikidata.org/entity/statement/Q860395-54018A2C-3A48-4092-A1DA-C141132966C5> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q860395-95F31FD8-A3DE-43BD-A379-521329D76A65> ;
+    p:P4746 <http://www.wikidata.org/entity/statement/Q860395-1DFA94C5-2C7E-4EF7-9DEA-162E338BF9A3> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q860395-07067B20-E7F5-483D-881F-3DB6F7A51104>,
+        <http://www.wikidata.org/entity/statement/Q860395-765829B1-C844-43E4-9CE5-CE54F3EEB71C> ;
+    p:P494 <http://www.wikidata.org/entity/statement/q860395-709B572B-A1F5-4F5A-B397-DD0DD7CA048D> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q860395-CAD48D1F-310A-483D-9F47-0EBC8F6239D6> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q860395-450DA92C-0258-4427-8184-E57290C7BBE8> ;
+    p:P604 <http://www.wikidata.org/entity/statement/q860395-202FA641-8FA2-42A7-BBBC-532B75A07259> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q860395-6876B29A-8B0D-4734-9B7E-FD4B20653C6B> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q860395-13812C8F-9ACF-40B5-8FDB-B0A49F6B3FDF>,
+        <http://www.wikidata.org/entity/statement/Q860395-858CE025-EB69-46D0-B44E-87C193043FEB>,
+        <http://www.wikidata.org/entity/statement/Q860395-E7C6BCD3-482B-486B-B13C-AA9DB89E6936>,
+        <http://www.wikidata.org/entity/statement/Q860395-F00FB9B7-A39E-4DBC-91EF-7FFDEBE760CD> ;
+    p:P673 <http://www.wikidata.org/entity/statement/q860395-12E17F23-21EB-4475-9AA1-3F475CC30867>,
+        <http://www.wikidata.org/entity/statement/q860395-5A119865-218D-4E8C-9CFB-C13E8699535C> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q860395-93310DC8-F3F8-48A0-91CC-98CBF90147AF>,
+        <http://www.wikidata.org/entity/statement/Q860395-D5C66933-D510-4C6E-A74E-74813A1E90E6> ;
+    ns2:P486 <http://id.nlm.nih.gov/mesh/D010018> ;
+    ns2:P646 <http://g.co/kg/m/02npcz> ;
+    ns2:P672 <https://id.nlm.nih.gov/mesh/C05.116.198.816.640>,
+        <https://id.nlm.nih.gov/mesh/C18.452.104.816.640>,
+        <https://id.nlm.nih.gov/mesh/C18.452.174.845.640>,
+        <https://id.nlm.nih.gov/mesh/C18.654.521.500.133.770.734.640> ;
+    wdt:P1343 wd:Q2657718 ;
+    wdt:P1417 "science/osteomalacia" ;
+    wdt:P1461 "vitamin-d-deficiency-including-osteomalacia-and-rickets" ;
+    wdt:P1692 "268.2" ;
+    wdt:P1748 "C26838" ;
+    wdt:P18 <http://commons.wikimedia.org/wiki/Special:FilePath/Calcitriol.svg> ;
+    wdt:P1995 wd:Q327657 ;
+    wdt:P2176 wd:Q408283 ;
+    wdt:P279 wd:Q18553736 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:10573>,
+        <http://purl.obolibrary.org/obo/DOID_10573>,
+        <http://purl.obolibrary.org/obo/HP_0002749> ;
+    wdt:P2892 "C0029442" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3827 "osteomalacia" ;
+    wdt:P3841 "HP:0002749" ;
+    wdt:P4317 "7285" ;
+    wdt:P4746 "029104" ;
+    wdt:P486 "D010018" ;
+    wdt:P494 "M83" ;
+    wdt:P5270 "MONDO:0001068" ;
+    wdt:P557 "9351" ;
+    wdt:P604 "000376" ;
+    wdt:P646 "/m/02npcz" ;
+    wdt:P672 "C05.116.198.816.640",
+        "C18.452.104.816.640",
+        "C18.452.174.845.640",
+        "C18.654.521.500.133.770.734.640" ;
+    wdt:P673 "412862",
+        "985510" ;
+    wdt:P699 "DOID:10573" .
+
+<http://www.wikidata.org/entity/statement/Q860395-07067B20-E7F5-483D-881F-3DB6F7A51104> prov:wasDerivedFrom <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P486 "D010018" .
+
+<http://www.wikidata.org/entity/statement/Q860395-3C0167EB-283E-4E32-BA3F-57AFB5992C88> prov:wasDerivedFrom <http://www.wikidata.org/reference/3b364ecce8083915c428d671f9c0a89d66df667a>,
+        <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc> ;
+    ps:P1748 "C26838" .
+
+<http://www.wikidata.org/entity/statement/Q860395-43CAB09C-8C77-41C7-B159-B3D96E6FE96B> prov:wasDerivedFrom <http://www.wikidata.org/reference/3b364ecce8083915c428d671f9c0a89d66df667a>,
+        <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc> ;
+    ps:P2892 "C0029442" .
+
+<http://www.wikidata.org/entity/statement/Q860395-582BD7A3-2FA2-452D-8882-4C668851C997> prov:wasDerivedFrom <http://www.wikidata.org/reference/05900fe8bbe5dd5c93f059a482d96db9b632b67e>,
+        <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P2892 "C0029442" .
+
+<http://www.wikidata.org/entity/statement/Q860395-765829B1-C844-43E4-9CE5-CE54F3EEB71C> prov:wasDerivedFrom <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P486 "D010018" .
+
+<http://www.wikidata.org/entity/statement/Q860395-93310DC8-F3F8-48A0-91CC-98CBF90147AF> prov:wasDerivedFrom <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P699 "DOID:10573" .
+
+<http://www.wikidata.org/entity/statement/Q860395-9FE199CE-6A82-4EC9-8B67-52C8A67BD66D> prov:wasDerivedFrom <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc>,
+        <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P279 wd:Q18553736 .
+
+<http://www.wikidata.org/entity/statement/Q860395-B6BA04B3-8E0C-4258-9EF6-FAF5120C9112> prov:wasDerivedFrom <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P1748 "C26838" .
+
+<http://www.wikidata.org/entity/statement/Q860395-C2F5365F-9E86-4F9E-84D0-C72290A0EDDD> prov:wasDerivedFrom <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc>,
+        <http://www.wikidata.org/reference/d6cd35039e2b642b51ab02f8457c384c673026e9> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q860395-D5C66933-D510-4C6E-A74E-74813A1E90E6> prov:wasDerivedFrom <http://www.wikidata.org/reference/3b364ecce8083915c428d671f9c0a89d66df667a>,
+        <http://www.wikidata.org/reference/92726220408299323ce1795a132ed02fdb9bb1bc> ;
+    ps:P699 "DOID:10573" .
+

--- a/tests/test_issues/data/wikidata/disease/Q883850.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q883850.ttl
@@ -1,0 +1,132 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q883850 rdfs:label "Blepharophimose",
+        "Blepharophimosis",
+        "blefarofimose",
+        "blefarofimosi",
+        "blepharophimosis",
+        "blépharophimosis",
+        "Блефарофимоз",
+        "تضيق الاجفان",
+        "先天性家族性瞼口狹小症" ;
+    schema:dateModified "2019-03-04T23:44:01+00:00"^^xsd:dateTime ;
+    schema:description "Human disease",
+        "Krankheit",
+        "réduction de la fente des paupières",
+        "مرض يصيب الإنسان" ;
+    schema:version 874531182 ;
+    ns2:identifiers 14 ;
+    ns2:sitelinks 7 ;
+    ns2:statements 22 ;
+    ns2:timestamp "2019-03-04T23:57:36+00:00"^^xsd:dateTime ;
+    skos:altLabel "BPES",
+        "Blepharophimose-Epikanthus inversus-Ptose-Syndrom",
+        "Blepharophimose-Ptosis-Epicanthus-inversus-Syndrom",
+        "Blepharophimose-Syndrom",
+        "Wrodzone zwężenie szpary powiekowej",
+        "blepharophimosis",
+        "الحوص",
+        "تضيق الأجفان",
+        "حوص" ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q883850-180E37D7-E001-4B0B-BCED-1A287A71B1D7> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q883850-6D3CDFDD-23BE-4B26-8504-4AA99E1DE256> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q883850-724141E5-030D-4BE8-BD8B-A29491427D80>,
+        <http://www.wikidata.org/entity/statement/Q883850-c25b9fab-492f-7be9-1c8b-67d1c9a8b2bf> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q883850-259E820A-83CC-4D27-B627-732896E26492>,
+        <http://www.wikidata.org/entity/statement/Q883850-B6A482A1-2186-4F30-8651-E90A1EFA727F>,
+        <http://www.wikidata.org/entity/statement/Q883850-F0DFC75C-9F26-496C-A1E8-A399C7A85A89> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q883850-7801DB60-3EAE-4F66-8611-ACF7D3744F49>,
+        <http://www.wikidata.org/entity/statement/Q883850-927DEE74-3BEA-45ED-859C-AF35924F9FFB> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q883850-3A46EECB-256E-4A9A-BA3D-5C9B58BDA9A9> ;
+    p:P3841 <http://www.wikidata.org/entity/statement/Q883850-315E673A-9877-4E68-83B8-CAAD32A06621> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q883850-0F768EC2-5AD0-4C66-B3F0-7A14E6268871> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q883850-4B3C0287-8552-409C-A717-3FCD6009C15B> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q883850-BC94F9BA-B0B4-4153-A125-317E561F094B>,
+        <http://www.wikidata.org/entity/statement/Q883850-E6FA97DE-5403-4DDA-962B-7C41357A6032> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q883850-9F594A35-1A09-4838-A73D-56A4F09C0F04> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q883850-7ABF7C06-389E-488D-B3AE-C5AC0E41500A> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q883850-663F0F33-4034-4253-9204-872F10B56D8B>,
+        <http://www.wikidata.org/entity/statement/Q883850-83ED7BF7-4BD3-4ADC-89A5-0855E1E37B6F>,
+        <http://www.wikidata.org/entity/statement/Q883850-A8067EA6-AE96-470E-B5F7-524C0432CBC6> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q883850-1675B5AD-54A3-49FD-861C-5ED20DB97305>,
+        <http://www.wikidata.org/entity/statement/Q883850-54BC6D88-1298-44A7-9CE9-34B6A7AAD842> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D016569> ;
+    ns1:P646 <http://g.co/kg/m/01xn0s0> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C11.250.090>,
+        <https://id.nlm.nih.gov/mesh/C11.338.190>,
+        <https://id.nlm.nih.gov/mesh/C16.131.384.190> ;
+    wdt:P1692 "374.46" ;
+    wdt:P1995 wd:Q1071953 ;
+    wdt:P279 wd:Q18556729,
+        wd:Q3281904 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:10348>,
+        <http://purl.obolibrary.org/obo/DOID_10348>,
+        <http://purl.obolibrary.org/obo/HP_0000581> ;
+    wdt:P2892 "C0005744" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3841 "HP:0000581" ;
+    wdt:P4229 "H02.52" ;
+    wdt:P4317 "5932" ;
+    wdt:P486 "D016569" ;
+    wdt:P5270 "MONDO:0001008" ;
+    wdt:P646 "/m/01xn0s0" ;
+    wdt:P672 "C11.250.090",
+        "C11.338.190",
+        "C16.131.384.190" ;
+    wdt:P699 "DOID:10348" .
+
+<http://www.wikidata.org/entity/statement/Q883850-0F768EC2-5AD0-4C66-B3F0-7A14E6268871> prov:wasDerivedFrom <http://www.wikidata.org/reference/31d38bde634618fede3bf1a07ba0438e5f3d20e3>,
+        <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P4229 "H02.52" .
+
+<http://www.wikidata.org/entity/statement/Q883850-1675B5AD-54A3-49FD-861C-5ED20DB97305> prov:wasDerivedFrom <http://www.wikidata.org/reference/0008b0e4b0d47c8f30308aff15ce3f3ab067d81d>,
+        <http://www.wikidata.org/reference/31d38bde634618fede3bf1a07ba0438e5f3d20e3> ;
+    ps:P699 "DOID:10348" .
+
+<http://www.wikidata.org/entity/statement/Q883850-3A46EECB-256E-4A9A-BA3D-5C9B58BDA9A9> prov:wasDerivedFrom <http://www.wikidata.org/reference/31d38bde634618fede3bf1a07ba0438e5f3d20e3>,
+        <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q883850-54BC6D88-1298-44A7-9CE9-34B6A7AAD842> prov:wasDerivedFrom <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P699 "DOID:10348" .
+
+<http://www.wikidata.org/entity/statement/Q883850-724141E5-030D-4BE8-BD8B-A29491427D80> prov:wasDerivedFrom <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P279 wd:Q18556729 .
+
+<http://www.wikidata.org/entity/statement/Q883850-7801DB60-3EAE-4F66-8611-ACF7D3744F49> prov:wasDerivedFrom <http://www.wikidata.org/reference/a861105a5ddfe376708acd92aba6ebf10e2a5362>,
+        <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P2892 "C0005744" .
+
+<http://www.wikidata.org/entity/statement/Q883850-927DEE74-3BEA-45ED-859C-AF35924F9FFB> prov:wasDerivedFrom <http://www.wikidata.org/reference/0008b0e4b0d47c8f30308aff15ce3f3ab067d81d>,
+        <http://www.wikidata.org/reference/31d38bde634618fede3bf1a07ba0438e5f3d20e3> ;
+    ps:P2892 "C0005744" .
+
+<http://www.wikidata.org/entity/statement/Q883850-BC94F9BA-B0B4-4153-A125-317E561F094B> prov:wasDerivedFrom <http://www.wikidata.org/reference/0008b0e4b0d47c8f30308aff15ce3f3ab067d81d>,
+        <http://www.wikidata.org/reference/31d38bde634618fede3bf1a07ba0438e5f3d20e3> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P486 "D016569" .
+
+<http://www.wikidata.org/entity/statement/Q883850-E6FA97DE-5403-4DDA-962B-7C41357A6032> prov:wasDerivedFrom <http://www.wikidata.org/reference/a861105a5ddfe376708acd92aba6ebf10e2a5362>,
+        <http://www.wikidata.org/reference/f662a25888cefdf24d53fb2d6b20ff0a423d2eca> ;
+    ps:P486 "D016569" .
+
+<http://www.wikidata.org/entity/statement/Q883850-c25b9fab-492f-7be9-1c8b-67d1c9a8b2bf> ps:P279 wd:Q3281904 .
+

--- a/tests/test_issues/data/wikidata/disease/Q896643.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q896643.ttl
@@ -1,0 +1,140 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q896643 rdfs:label "Brachydaktylia",
+        "Brachydaktylie",
+        "Braquidactília",
+        "brachidattilia",
+        "brachydactylie",
+        "brachydactyly",
+        "braquidactilia",
+        "hammartumme",
+        "Брахидактилия",
+        "Брахидактилија",
+        "Брахідактилія",
+        "ברכידקטיליה",
+        "قصر الأصابع",
+        "短指症",
+        "단지증" ;
+    schema:dateModified "2019-03-04T23:01:57+00:00"^^xsd:dateTime ;
+    schema:description "Krankheit",
+        "bone development disease characterized by short fingers and toes",
+        "malformación genética" ;
+    schema:version 874507065 ;
+    ns2:identifiers 19 ;
+    ns2:sitelinks 17 ;
+    ns2:statements 28 ;
+    ns2:timestamp "2019-03-04T23:02:11+00:00"^^xsd:dateTime ;
+    skos:altLabel "Brachidactilia",
+        "Krótkopalczastość",
+        "Kurzfingrigkeit",
+        "brachydactyly",
+        "isolated brachydactyly",
+        "nonsyndromic brachydactyly",
+        "Краткопрстост",
+        "ברכידקטילי",
+        "الكزم",
+        "先天性第四蹠骨短小症",
+        "短趾症",
+        "짧은가락증" ;
+    p:P1550 <http://www.wikidata.org/entity/statement/Q896643-187CB364-0829-4E53-9D89-38A300FB35BF>,
+        <http://www.wikidata.org/entity/statement/Q896643-2A462309-2DE4-464A-AF91-3BEB22AACC8E>,
+        <http://www.wikidata.org/entity/statement/Q896643-2a7378bf-454e-7d2f-c4a1-5a8948056add> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q896643-73001F56-32A3-4329-9FE0-FEF23B90C1A2> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q896643-18fbc5f8-4125-d246-1e94-8fd64c441196>,
+        <http://www.wikidata.org/entity/statement/Q896643-D1AF7144-A09F-48C4-9F63-25713B78172A> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q896643-0FD24213-E275-4899-8561-FA796415B5E5>,
+        <http://www.wikidata.org/entity/statement/Q896643-19EECFC1-263A-47CE-8E30-4E70E86E83F3>,
+        <http://www.wikidata.org/entity/statement/Q896643-66EBC05E-17C0-43B4-ACAE-6802E195251E>,
+        <http://www.wikidata.org/entity/statement/Q896643-766BCD8F-4C97-446A-9408-F24C31C1B1E2> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q896643-4EB462D1-16A0-4A5D-BD5B-862132A57DF6>,
+        <http://www.wikidata.org/entity/statement/Q896643-68D22C78-81F9-4E99-B240-574F9F8B7D8D> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q896643-0F0DDB43-FD00-4DF9-948C-CEAD3BF25736> ;
+    p:P3827 <http://www.wikidata.org/entity/statement/Q896643-D854251D-76C6-4183-B69D-E03EC820E59A> ;
+    p:P3841 <http://www.wikidata.org/entity/statement/Q896643-B6923C8E-749F-4D47-9C26-EFB60A41B825> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q896643-B4B0B769-7FA2-42CE-BA73-710FCB565AE4> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q896643-8A62F4B7-E4C2-4FC1-98AF-B0E91CCB9385> ;
+    p:P493 <http://www.wikidata.org/entity/statement/q896643-38313821-259B-46C1-BC49-3E04E3CE2FC9>,
+        <http://www.wikidata.org/entity/statement/q896643-89074457-67F7-4276-B3DF-36886A86C012>,
+        <http://www.wikidata.org/entity/statement/q896643-FE17423E-8693-44B5-A3D0-9ACCF8AD1EB3> ;
+    p:P494 <http://www.wikidata.org/entity/statement/q896643-25DD802A-E225-4E6B-A4D3-694D79188AE8> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q896643-229C5670-42B4-4813-93E2-CFDECBBD5AF7> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q896643-40E7764C-9056-4A1A-B99A-A57410456C24> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q896643-6BC6474E-EDC9-4E37-88C8-A932628CB203> ;
+    p:P667 <http://www.wikidata.org/entity/statement/Q896643-EC8FB522-A3FD-4FF9-BB2E-D87FA715D768> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q896643-01EC4317-E0DA-4533-9458-1E9B463F1059>,
+        <http://www.wikidata.org/entity/statement/Q896643-69CEAD25-713F-4616-AAED-0F14120BEEE7> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q896643-1BE1A4E4-AB40-40BB-836C-A7C9BB0FD773> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/D059327> ;
+    ns1:P646 <http://g.co/kg/m/0mdcl> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C05.660.585.262>,
+        <https://id.nlm.nih.gov/mesh/C16.131.621.585.262> ;
+    wdt:P1550 "294937",
+        "69028" ;
+    wdt:P1995 wd:Q1071953 ;
+    wdt:P279 wd:Q1269307,
+        wd:Q54943715 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:0050581>,
+        <http://purl.obolibrary.org/obo/DOID_0050581>,
+        <http://purl.obolibrary.org/obo/HP_0001156>,
+        <http://www.orpha.net/ORDO/Orphanet_294937> ;
+    wdt:P2892 "C0221357" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3827 "brachydactyly" ;
+    wdt:P3841 "HP:0001156" ;
+    wdt:P4317 "11913" ;
+    wdt:P486 "D059327" ;
+    wdt:P493 "755.2",
+        "755.3",
+        "755.4" ;
+    wdt:P494 "Q68.1" ;
+    wdt:P5270 "MONDO:0017424" ;
+    wdt:P557 "29782" ;
+    wdt:P646 "/m/0mdcl" ;
+    wdt:P667 "L82" ;
+    wdt:P672 "C05.660.585.262",
+        "C16.131.621.585.262" ;
+    wdt:P699 "DOID:0050581" .
+
+<http://www.wikidata.org/entity/statement/Q896643-0F0DDB43-FD00-4DF9-948C-CEAD3BF25736> prov:wasDerivedFrom <http://www.wikidata.org/reference/3e9b22c37a28ff8bcfe7e395e59f3420eef96d86> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/Q896643-18fbc5f8-4125-d246-1e94-8fd64c441196> ps:P279 wd:Q54943715 .
+
+<http://www.wikidata.org/entity/statement/Q896643-1BE1A4E4-AB40-40BB-836C-A7C9BB0FD773> prov:wasDerivedFrom <http://www.wikidata.org/reference/3e9b22c37a28ff8bcfe7e395e59f3420eef96d86> ;
+    ps:P699 "DOID:0050581" .
+
+<http://www.wikidata.org/entity/statement/Q896643-2a7378bf-454e-7d2f-c4a1-5a8948056add> ps:P1550 "69028" .
+
+<http://www.wikidata.org/entity/statement/Q896643-8A62F4B7-E4C2-4FC1-98AF-B0E91CCB9385> prov:wasDerivedFrom <http://www.wikidata.org/reference/30254309a9c7ad97490c0750a95f4cc98b364d3b> ;
+    ps:P486 "D059327" .
+
+<http://www.wikidata.org/entity/statement/Q896643-D1AF7144-A09F-48C4-9F63-25713B78172A> prov:wasDerivedFrom <http://www.wikidata.org/reference/3e9b22c37a28ff8bcfe7e395e59f3420eef96d86> ;
+    ps:P279 wd:Q1269307 .
+
+<http://www.wikidata.org/entity/statement/q896643-38313821-259B-46C1-BC49-3E04E3CE2FC9> prov:wasDerivedFrom <http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1> ;
+    ps:P493 "755.3" .
+
+<http://www.wikidata.org/entity/statement/q896643-89074457-67F7-4276-B3DF-36886A86C012> prov:wasDerivedFrom <http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1> ;
+    ps:P493 "755.2" .
+
+<http://www.wikidata.org/entity/statement/q896643-FE17423E-8693-44B5-A3D0-9ACCF8AD1EB3> prov:wasDerivedFrom <http://www.wikidata.org/reference/fa278ebfc458360e5aed63d5058cca83c46134f1> ;
+    ps:P493 "755.4" .
+

--- a/tests/test_issues/data/wikidata/disease/Q913856.ttl
+++ b/tests/test_issues/data/wikidata/disease/Q913856.ttl
@@ -1,0 +1,261 @@
+@prefix do: <http://purl.obolibrary.org/obo/DOID_> .
+@prefix doio: <http://identifiers.org/doid/> .
+@prefix mir: <http://www.ebi.ac.uk/miriam/main/collections/> .
+@prefix ns1: <http://www.wikidata.org/prop/direct-normalized/> .
+@prefix ns2: <http://wikiba.se/ontology#> .
+@prefix p: <http://www.wikidata.org/prop/> .
+@prefix pq: <http://www.wikidata.org/prop/qualifier/> .
+@prefix pr: <http://www.wikidata.org/prop/reference/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix prv: <http://www.wikidata.org/prop/reference/value/> .
+@prefix ps: <http://www.wikidata.org/prop/statement/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix wd: <http://www.wikidata.org/entity/> .
+@prefix wdt: <http://www.wikidata.org/prop/direct/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+wd:Q913856 rdfs:label "Ataksia Friedreich",
+        "Ataxie van Friedreich",
+        "Choroba Friedreicha",
+        "Fridrajhova ataksija",
+        "Friedreich ataksisi",
+        "Friedreich ataxia",
+        "Friedreich-Ataxie",
+        "Friedreich-ataxia",
+        "Friedreichova ataxie",
+        "Friedreichs ataxi",
+        "atassia di Friedreich",
+        "ataxia de Friedreich",
+        "ataxie de Friedreich",
+        "atàxia de Friedreich",
+        "Атаксия Фридрейха",
+        "Фридрајхова атаксија",
+        "אטקסיית פרידרייך",
+        "آتاکسی فردریش",
+        "رنح فريدريخ",
+        "フリードライヒ運動失調症",
+        "弗里德希氏共济失调",
+        "弗里德賴希氏共濟失調",
+        "弗里德赖希氏共济失调" ;
+    schema:dateModified "2019-03-05T01:59:08+00:00"^^xsd:dateTime ;
+    schema:description "Anomalia genetica che, nel tempo, causa danni al sistema nervoso.",
+        "Human disease",
+        "Krankheit",
+        "systémová atrofie postihující primárně centrální nervovou soustavu",
+        "مرض يصيب الإنسان" ;
+    schema:version 874603262 ;
+    ns2:identifiers 34 ;
+    ns2:sitelinks 21 ;
+    ns2:statements 48 ;
+    ns2:timestamp "2019-03-05T01:59:11+00:00"^^xsd:dateTime ;
+    skos:altLabel "Ataksja Friedreicha",
+        "Bezład Friedreicha",
+        "Dziedziczna ataksja rdzeniowa",
+        "FA",
+        "FRDA",
+        "FRIEDREICH ATAXIA 1; FRDA",
+        "Frda1",
+        "Friedreich Ataxia With Retained Reflexes",
+        "Friedreich Ataxia type 1",
+        "Friedreich ataxia 1",
+        "Friedreich's ataxia",
+        "Friedreich's tabes",
+        "Friedreichsche Ataxie",
+        "Friedreichsche Krankheit",
+        "Hereditary spinal ataxia",
+        "Hereditary spinal sclerosis",
+        "Morbus Friedreich",
+        "Spinocerebellar ataxia, Friedreich",
+        "Zwyrodnienie rdzeniowo-móżdżkowe",
+        "ataxia Friedreich",
+        "ataxia espinal",
+        "ataxia espinal hereditaria familiar",
+        "ataxia familiar",
+        "atàxia familiar",
+        "maladie de Friedreich",
+        "Болезнь Фридрейха",
+        "Стопа Фридрейха",
+        "Фридрейхова болезнь",
+        "אטקסיית פרידריך",
+        "اتاکسی فردریش",
+        "رنح فريدريش",
+        "遺傳性共濟失調症" ;
+    p:P138 <http://www.wikidata.org/entity/statement/Q913856-E15D1E0A-C251-44B1-A395-3FC3A08E93A8> ;
+    p:P1417 <http://www.wikidata.org/entity/statement/Q913856-A6CAABBA-F7F0-4B90-B7A6-DCDF7F49A7E7> ;
+    p:P1461 <http://www.wikidata.org/entity/statement/Q913856-ED03909E-2253-4518-8C1E-2D1626666ACF> ;
+    p:P1550 <http://www.wikidata.org/entity/statement/Q913856-129D97A6-7AB9-4E7B-BC8E-FBD937B23A5E> ;
+    p:P1692 <http://www.wikidata.org/entity/statement/Q913856-A153DD4B-0B38-4188-A743-444B07D95537> ;
+    p:P1748 <http://www.wikidata.org/entity/statement/Q913856-87463C4B-DDD8-48A1-9567-4442501A1268>,
+        <http://www.wikidata.org/entity/statement/Q913856-8A5FD04E-F4F0-4BE6-AEE4-7C4FBBFF739A> ;
+    p:P1995 <http://www.wikidata.org/entity/statement/Q913856-E58E3CDF-0196-4A91-8593-97E176BC5BE0> ;
+    p:P244 <http://www.wikidata.org/entity/statement/Q913856-b7b0d96c-445c-a97f-54c1-53996302c373> ;
+    p:P279 <http://www.wikidata.org/entity/statement/Q913856-1CD0B7DC-AC88-49AC-92CF-7CFDC308D197>,
+        <http://www.wikidata.org/entity/statement/Q913856-8DFE1F39-C75E-416F-B20C-C2CCE636C14F> ;
+    p:P2888 <http://www.wikidata.org/entity/statement/Q913856-48C618C5-5547-4633-B220-6DBC5BF7793B>,
+        <http://www.wikidata.org/entity/statement/Q913856-7F4BB5EB-0475-407A-8F4D-8F13E4EC342E>,
+        <http://www.wikidata.org/entity/statement/Q913856-C2920D7B-16D9-4964-AE7A-E29EFFDB52AC>,
+        <http://www.wikidata.org/entity/statement/Q913856-E7CCBF49-327A-4903-BB3F-52B012A9590A> ;
+    p:P2892 <http://www.wikidata.org/entity/statement/Q913856-0375675A-5EBB-454F-93E2-0E6B70F34C25>,
+        <http://www.wikidata.org/entity/statement/Q913856-369F8267-6A12-4FE0-94E2-2EDE16B54E49>,
+        <http://www.wikidata.org/entity/statement/Q913856-7FE0F2D0-A237-4ADA-A423-202F6DC4D501>,
+        <http://www.wikidata.org/entity/statement/Q913856-BE647EC1-FF57-4E63-B0D2-68BB2C6738F9>,
+        <http://www.wikidata.org/entity/statement/Q913856-D55E5E7C-F467-4D4C-8197-B401D3022110> ;
+    p:P31 <http://www.wikidata.org/entity/statement/Q913856-DA278A21-C6B3-4511-98D8-1C4BE19904E4> ;
+    p:P3417 <http://www.wikidata.org/entity/statement/Q913856-879D60CC-3FA9-4C7C-A9F0-A5A2641A4466> ;
+    p:P3841 <http://www.wikidata.org/entity/statement/Q913856-3411BAB9-70D2-4836-AD98-A296A0FA1E55> ;
+    p:P4229 <http://www.wikidata.org/entity/statement/Q913856-A6B03F43-E2A3-4F8C-A7E6-A3124EBC4079> ;
+    p:P4317 <http://www.wikidata.org/entity/statement/Q913856-66D64529-D4B8-4519-A257-9E8F60F43E3C> ;
+    p:P486 <http://www.wikidata.org/entity/statement/Q913856-14BDE22F-8A6F-49E0-9B18-03703CB12158>,
+        <http://www.wikidata.org/entity/statement/Q913856-81B66655-DF00-428C-9953-3E11385170BC>,
+        <http://www.wikidata.org/entity/statement/Q913856-B68F02C6-3285-4EEE-8C82-6251B05833F8> ;
+    p:P492 <http://www.wikidata.org/entity/statement/Q913856-2554BEEF-1592-4288-91B3-CC1A1F369A1C>,
+        <http://www.wikidata.org/entity/statement/Q913856-5AF11842-F924-4C14-B5C6-125C1474D67B>,
+        <http://www.wikidata.org/entity/statement/Q913856-671FB8B7-411F-4170-8BB2-76251CC3260A>,
+        <http://www.wikidata.org/entity/statement/q913856-C8C58D14-742C-4E5C-B0CA-CF928C8D2EB0> ;
+    p:P494 <http://www.wikidata.org/entity/statement/q913856-5A1727CB-25D6-4365-B848-A3909CFAF516> ;
+    p:P508 <http://www.wikidata.org/entity/statement/q913856-C3B12E37-23DB-42F9-B626-B193060E3209> ;
+    p:P5270 <http://www.wikidata.org/entity/statement/Q913856-364D5E38-BA3A-4D44-9646-1B23B9CC9AAE> ;
+    p:P557 <http://www.wikidata.org/entity/statement/q913856-01714E2D-4896-438B-81C7-673938E826DE> ;
+    p:P604 <http://www.wikidata.org/entity/statement/q913856-CBA42119-85DF-43CA-AFF2-EE10B41D0150> ;
+    p:P646 <http://www.wikidata.org/entity/statement/Q913856-BC094783-7B02-4D20-B29C-C14F3DBD393D> ;
+    p:P667 <http://www.wikidata.org/entity/statement/Q913856-45DBA404-32BD-4145-A8BA-9AA3AA4356AE> ;
+    p:P668 <http://www.wikidata.org/entity/statement/q913856-77866351-A38D-4AC0-9112-E052084BEC15> ;
+    p:P672 <http://www.wikidata.org/entity/statement/Q913856-39AA6A31-5CC6-4A5A-B51F-4F3ACC4D907E>,
+        <http://www.wikidata.org/entity/statement/Q913856-3AEE9B2B-BA9C-47AE-91F9-B084AB064511>,
+        <http://www.wikidata.org/entity/statement/Q913856-63A4EA7C-C0D7-493C-8A45-F6B77C0F92BA>,
+        <http://www.wikidata.org/entity/statement/Q913856-A3E47A5C-F521-483A-9EA4-AA0242B680D2>,
+        <http://www.wikidata.org/entity/statement/Q913856-C05F1672-5BBC-4BDB-A0BB-868C0DCCAE98> ;
+    p:P673 <http://www.wikidata.org/entity/statement/q913856-F5923D42-2F51-4AE6-8C72-2C529C227E99> ;
+    p:P699 <http://www.wikidata.org/entity/statement/Q913856-4ADDA17A-477D-440F-ACEF-D5BF7C9F33C8>,
+        <http://www.wikidata.org/entity/statement/Q913856-AA5F9CF8-F81F-457B-AC76-C795EA8ADCE6> ;
+    ns1:P244 <http://id.loc.gov/authorities/names/sh85051980> ;
+    ns1:P486 <http://id.nlm.nih.gov/mesh/C563014>,
+        <http://id.nlm.nih.gov/mesh/D005621> ;
+    ns1:P508 <http://purl.org/bncf/tid/32523> ;
+    ns1:P646 <http://g.co/kg/m/05ftf4> ;
+    ns1:P672 <https://id.nlm.nih.gov/mesh/C10.228.140.252.700.150>,
+        <https://id.nlm.nih.gov/mesh/C10.228.854.787.200>,
+        <https://id.nlm.nih.gov/mesh/C10.574.500.825.200>,
+        <https://id.nlm.nih.gov/mesh/C16.320.400.780.200>,
+        <https://id.nlm.nih.gov/mesh/C18.452.660.300> ;
+    wdt:P138 wd:Q70918 ;
+    wdt:P1417 "science/Friedreich-ataxia" ;
+    wdt:P1461 "friedreichs-ataxia" ;
+    wdt:P1550 "95" ;
+    wdt:P1692 "334.0" ;
+    wdt:P1748 "C84718" ;
+    wdt:P1995 wd:Q83042 ;
+    wdt:P244 "sh85051980" ;
+    wdt:P279 wd:Q4826996,
+        wd:Q55346094 ;
+    wdt:P2888 <http://identifiers.org/doid/DOID:12705>,
+        <http://purl.obolibrary.org/obo/DOID_12705>,
+        <http://purl.obolibrary.org/obo/HP_0005323>,
+        <http://www.orpha.net/ORDO/Orphanet_95> ;
+    wdt:P2892 "C0016719",
+        "C1399354",
+        "C1847416",
+        "C1856689" ;
+    wdt:P31 wd:Q12136 ;
+    wdt:P3417 "Friedreich-Ataxia" ;
+    wdt:P3841 "HP:0005323" ;
+    wdt:P4229 "G11.1" ;
+    wdt:P4317 "6468" ;
+    wdt:P486 "C563014",
+        "D005621" ;
+    wdt:P492 "229300",
+        "601992" ;
+    wdt:P494 "G11.1" ;
+    wdt:P508 "32523" ;
+    wdt:P5270 "MONDO:0009245" ;
+    wdt:P557 "4980" ;
+    wdt:P604 "001411" ;
+    wdt:P646 "/m/05ftf4" ;
+    wdt:P667 "N99" ;
+    wdt:P668 "NBK1281" ;
+    wdt:P672 "C10.228.140.252.700.150",
+        "C10.228.854.787.200",
+        "C10.574.500.825.200",
+        "C16.320.400.780.200",
+        "C18.452.660.300" ;
+    wdt:P673 "1150420" ;
+    wdt:P699 "DOID:12705" .
+
+<http://www.wikidata.org/entity/statement/Q913856-0375675A-5EBB-454F-93E2-0E6B70F34C25> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c> ;
+    ps:P2892 "C1856689" .
+
+<http://www.wikidata.org/entity/statement/Q913856-129D97A6-7AB9-4E7B-BC8E-FBD937B23A5E> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c> ;
+    ps:P1550 "95" .
+
+<http://www.wikidata.org/entity/statement/Q913856-14BDE22F-8A6F-49E0-9B18-03703CB12158> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2>,
+        <http://www.wikidata.org/reference/ee655014094ca6a03672682075149f4688360d49> ;
+    ps:P486 "D005621" .
+
+<http://www.wikidata.org/entity/statement/Q913856-1CD0B7DC-AC88-49AC-92CF-7CFDC308D197> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P279 wd:Q4826996 .
+
+<http://www.wikidata.org/entity/statement/Q913856-2554BEEF-1592-4288-91B3-CC1A1F369A1C> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P492 "229300" .
+
+<http://www.wikidata.org/entity/statement/Q913856-369F8267-6A12-4FE0-94E2-2EDE16B54E49> prov:wasDerivedFrom <http://www.wikidata.org/reference/ee655014094ca6a03672682075149f4688360d49> ;
+    ps:P2892 "C1399354" .
+
+<http://www.wikidata.org/entity/statement/Q913856-4ADDA17A-477D-440F-ACEF-D5BF7C9F33C8> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P699 "DOID:12705" .
+
+<http://www.wikidata.org/entity/statement/Q913856-5AF11842-F924-4C14-B5C6-125C1474D67B> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    pq:P4390 wd:Q39893967 ;
+    ps:P492 "601992" .
+
+<http://www.wikidata.org/entity/statement/Q913856-671FB8B7-411F-4170-8BB2-76251CC3260A> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P492 "601992" .
+
+<http://www.wikidata.org/entity/statement/Q913856-7FE0F2D0-A237-4ADA-A423-202F6DC4D501> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    ps:P2892 "C0016719" .
+
+<http://www.wikidata.org/entity/statement/Q913856-81B66655-DF00-428C-9953-3E11385170BC> prov:wasDerivedFrom <http://www.wikidata.org/reference/ee655014094ca6a03672682075149f4688360d49> ;
+    ps:P486 "C563014" .
+
+<http://www.wikidata.org/entity/statement/Q913856-87463C4B-DDD8-48A1-9567-4442501A1268> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    ps:P1748 "C84718" .
+
+<http://www.wikidata.org/entity/statement/Q913856-8A5FD04E-F4F0-4BE6-AEE4-7C4FBBFF739A> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P1748 "C84718" .
+
+<http://www.wikidata.org/entity/statement/Q913856-8DFE1F39-C75E-416F-B20C-C2CCE636C14F> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c> ;
+    ps:P279 wd:Q55346094 .
+
+<http://www.wikidata.org/entity/statement/Q913856-A6B03F43-E2A3-4F8C-A7E6-A3124EBC4079> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c> ;
+    ps:P4229 "G11.1" .
+
+<http://www.wikidata.org/entity/statement/Q913856-AA5F9CF8-F81F-457B-AC76-C795EA8ADCE6> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    ps:P699 "DOID:12705" .
+
+<http://www.wikidata.org/entity/statement/Q913856-B68F02C6-3285-4EEE-8C82-6251B05833F8> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P486 "D005621" .
+
+<http://www.wikidata.org/entity/statement/Q913856-BE647EC1-FF57-4E63-B0D2-68BB2C6738F9> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c> ;
+    ps:P2892 "C1847416" .
+
+<http://www.wikidata.org/entity/statement/Q913856-D55E5E7C-F467-4D4C-8197-B401D3022110> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2>,
+        <http://www.wikidata.org/reference/ee655014094ca6a03672682075149f4688360d49> ;
+    ps:P2892 "C0016719" .
+
+<http://www.wikidata.org/entity/statement/Q913856-DA278A21-C6B3-4511-98D8-1C4BE19904E4> prov:wasDerivedFrom <http://www.wikidata.org/reference/43b63f5e1e1858e4a439bf46185fe0080fe422b2> ;
+    ps:P31 wd:Q12136 .
+
+<http://www.wikidata.org/entity/statement/q913856-C8C58D14-742C-4E5C-B0CA-CF928C8D2EB0> prov:wasDerivedFrom <http://www.wikidata.org/reference/125eff4adeb25d81675e040909117ca696e4507c>,
+        <http://www.wikidata.org/reference/7c9d5178e49f44a31cf935ef23f531a87be07da2> ;
+    pq:P4390 wd:Q39893449 ;
+    ps:P492 "229300" .
+

--- a/tests/test_issues/test_issue_41.py
+++ b/tests/test_issues/test_issue_41.py
@@ -1,0 +1,57 @@
+import unittest
+from pprint import pprint
+
+from rdflib import Graph, Namespace
+
+from pyshex import ShExEvaluator
+
+rdf = """
+@prefix : <http://example.org/model/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<http://example.org/context/42> a :Person ;
+    foaf:age 43 ;
+    foaf:firstName "Bob",
+        "Joe" ;
+    foaf:lastName "smith" .
+"""
+
+shex = """
+<http://example.org/sample/example1/String> <http://www.w3.org/2001/XMLSchema#string>
+<http://example.org/sample/example1/Int> <http://www.w3.org/2001/XMLSchema#integer>
+<http://example.org/sample/example1/Boolean> <http://www.w3.org/2001/XMLSchema#boolean>
+<http://example.org/sample/example1/Person> CLOSED {
+    (  <http://xmlns.com/foaf/0.1/firstName> @<http://example.org/sample/example1/String> * ;
+       <http://xmlns.com/foaf/0.1/lastName> @<http://example.org/sample/example1/String> ;
+       <http://xmlns.com/foaf/0.1/age> @<http://example.org/sample/example1/Int> ? ;
+       <http://example.org/model/living> @<http://example.org/sample/example1/Boolean> ? ;
+       <http://xmlns.com/foaf/0.1/knows> @<http://example.org/sample/example1/Person> *
+    )
+}
+"""
+
+EXC = Namespace("http://example.org/context/")
+EXE = Namespace("http://example.org/sample/example1/")
+
+
+class Issue41TestCase(unittest.TestCase):
+    def test_closed(self):
+        """ Test closed definition """
+
+        e = ShExEvaluator(rdf=rdf, schema=shex, focus=EXC['42'], start=EXE.Person)
+        # This causes issue 42
+        # pprint(e.evaluate())
+        self.assertFalse(e.evaluate()[0].result)
+
+        from pyshex.evaluate import evaluate
+        g = Graph()
+        g.parse(data=rdf, format="turtle")
+        pprint(evaluate(g, shex, focus=EXC['42'], start=EXE.Person))
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,6 @@ envlist = py37 py36
 
 [testenv]
 deps=unittest2
+whitelist_externals = python
 commands=python -m unittest
 


### PR DESCRIPTION
This issue only appeared when using the `evaluate` call.