### PR TITLE
Fix issue #51 -- include nested te labels and report errors at runtime.

### DIFF
--- a/pyshex/shape_expressions_language/p5_5_shapes_and_triple_expressions.py
+++ b/pyshex/shape_expressions_language/p5_5_shapes_and_triple_expressions.py
@@ -319,8 +319,8 @@ def matchesTripleExprRef(cntxt: Context, T: RDFGraph, expr: ShExJ.tripleExprLabe
     expr is an tripleExprRef and satisfies(value, tripleExprWithId(tripleExprRef), G, m).
     The tripleExprWithId function is defined in Triple Expression Reference Requirement below.
     """
-    expr = cntxt.tripleExprFor(expr)
-    if expr is None:
-        cntxt.fail_reason = "{expr}: Reference not found"
+    tefor_expr = cntxt.tripleExprFor(expr)
+    if tefor_expr is None:
+        cntxt.fail_reason = f"{expr}: Reference not found"
         return False
-    return matchesExpr(cntxt, T, expr)
+    return matchesExpr(cntxt, T, tefor_expr)

--- a/pyshex/shape_expressions_language/p5_context.py
+++ b/pyshex/shape_expressions_language/p5_context.py
@@ -218,14 +218,14 @@ class Context:
             abs_id = self._resolve_relative_uri(expr.id)
             if abs_id not in self.schema_id_map:
                 self.schema_id_map[abs_id] = expr
-                if isinstance(expr, (ShExJ.ShapeOr, ShExJ.ShapeAnd)):
-                    for expr2 in expr.shapeExprs:
-                        self._gen_schema_xref(expr2)
-                elif isinstance(expr, ShExJ.ShapeNot):
-                    self._gen_schema_xref(expr.shapeExpr)
-                elif isinstance(expr, ShExJ.Shape):
-                    if expr.expression is not None:
-                        self._gen_te_xref(expr.expression)
+        if isinstance(expr, (ShExJ.ShapeOr, ShExJ.ShapeAnd)):
+            for expr2 in expr.shapeExprs:
+                self._gen_schema_xref(expr2)
+        elif isinstance(expr, ShExJ.ShapeNot):
+            self._gen_schema_xref(expr.shapeExpr)
+        elif isinstance(expr, ShExJ.Shape):
+            if expr.expression is not None:
+                self._gen_te_xref(expr.expression)
 
     def _resolve_relative_uri(self, ref: Union[URIRef, BNode, ShExJ.shapeExprLabel]) -> ShExJ.shapeExprLabel:
         return ShExJ.IRIREF(str(self.base_namespace[str(ref)])) if ':' not in str(ref) and self.base_namespace else ref

--- a/tests/data/earl_report.ttl
+++ b/tests/data/earl_report.ttl
@@ -43,8476 +43,7 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.426332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.431194" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.846631" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.952990" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.763876" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.335353" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.746745" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.640799" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.553825" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.225649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.506596" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.047126" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.868835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.530199" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.478643" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.746518" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.876143" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.826144" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.922829" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.648198" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.244409" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.512509" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.256570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.880228" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.916277" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.378544" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.550319" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.221265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.938193" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.776348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.594534" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.402192" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.309924" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.512879" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.127007" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.562518" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.677892" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.640516" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.592044" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.786435" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.515754" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.526026" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.975712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.709039" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.664248" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.023350" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.172103" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.860148" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.225898" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.290477" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.950320" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.014939" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.065491" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.921567" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.864241" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.779876" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.239265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.742324" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.495361" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.048275" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.013951" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.176314" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.689344" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.767127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.583968" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.116659" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.753524" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.463329" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.970024" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.664614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.237814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.867172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.634620" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.108799" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.644624" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.200922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.926410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.077661" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.793846" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.115171" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.236900" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.370945" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.115234" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.260742" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.573028" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.694389" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.368744" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.158328" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.249156" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.722680" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.983463" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.073092" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.983737" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.916257" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.661088" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.816539" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.977729" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.890385" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.502758" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.257488" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.204300" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.637029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.237741" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.037532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.538554" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.955031" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.798586" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.084003" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.122208" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.188424" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.769340" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.045569" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.392780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.664778" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.696201" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.334891" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.667671" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.557956" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.147069" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.521146" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.330787" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.316668" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.197040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.020328" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.224333" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.532323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdot3Extra_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.407974" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.118994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.220317" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.669570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.004746" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.395494" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.269766" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.769467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.343162" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.632398" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.396403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.961721" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.508222" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.144603" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.819792" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.800467" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.181975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.730260" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.715027" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.731532" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.483645" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.087446" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.471759" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.718124" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.253271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.715149" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.943226" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.161854" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.442186" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.117000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.069186" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.285370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.391564" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.246737" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.630891" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.133683" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.041626" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.968662" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.685381" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.518831" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.827189" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.348370" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.401541" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.855198" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.656743" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.894253" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.673844" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.050599" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.579068" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.711937" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.681632" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.461332" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.217476" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.253641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.759789" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.546050" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.295795" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.892823" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.474271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.137920" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.306775" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.835269" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.459129" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.909292" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.685164" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.008227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.356779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.934917" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.793439" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.104961" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.012520" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.178718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.715056" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.738994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.631944" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.346576" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.137247" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.955456" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.468489" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.683491" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.746550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.527227" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.131774" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.682100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.123541" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.682641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.923909" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.785072" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.207436" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.679165" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.054836" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.413357" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.360676" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.045898" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.515781" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.106519" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.821122" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.935843" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.722144" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.676009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.080328" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.990336" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.596029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.661914" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.349513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.919882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.674483" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.712218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.668843" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.835032" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.219480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.291056" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.616641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.770354" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.404889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.753482" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.665407" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.735142" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.590367" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.683083" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.473931" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.531893" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.167289" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.542500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.859719" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.730620" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.201260" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.672721" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.536219" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.713448" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.332205" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.898487" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.150853" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.557797" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.494154" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.775610" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.377765" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.772839" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.401169" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.084159" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.080986" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.310119" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.406568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.786981" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.540327" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.214500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.666742" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.111065" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.056056" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.104934" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.914649" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.525677" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.751195" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.832124" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.093714" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.655392" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.867446" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.150963" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.606771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.765282" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.643471" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.265306" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.994880" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.102352" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.461676" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.160303" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.955396" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.227224" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.439526" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.747206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.796643" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.019291" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.734728" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.322970" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.963421" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.398617" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.827241" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.231000" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.154542" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.769686" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.128114" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.356980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.617730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.673020" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.620742" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.110691" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.893071" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.649577" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.691436" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.568214" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.649987" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.304077" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.750134" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.409314" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.733225" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.363199" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.238942" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.669036" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.094878" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.997550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.234195" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.927717" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.208251" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.140214" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.986488" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.245093" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.827585" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.956960" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.806710" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.363252" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.354921" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.938480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.410457" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.967580" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.204437" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.701960" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.282211" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.628052" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.371330" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.704875" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.685540" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.990472" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.340525" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.765228" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.655273" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.898794" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.788826" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.299999" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.423211" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.453570" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.565813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.754864" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.387994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.430952" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.219202" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.730983" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.643963" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.823537" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.871636" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.754388" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.443206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.656477" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.140162" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.704131" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.821475" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.506501" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.148935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.261308" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.226348" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.489108" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.753953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.748275" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.306718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.840902" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.743693" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.121609" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.932276" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.935963" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.993053" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.447353" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.774034" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.660529" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.374454" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.097517" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.927074" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.089028" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.345584" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.604003" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.716796" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.322486" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.382494" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.738389" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.216033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.589188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.738265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.482664" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.913094" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.467959" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.383891" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.651763" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.652206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.041231" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.910820" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.726697" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.004077" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.239976" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.175119" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.419526" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.668191" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.577135" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.706661" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.721339" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.951731" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.811563" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.392866" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.047057" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.560547" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.419500" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.495271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.384518" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.210723" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.380744" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.705537" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.313163" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.153853" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.584077" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.088127" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.805933" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.985994" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.164130" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#repeated-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.734122" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.649543" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.371052" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.092670" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.811271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.360416" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.906481" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.389114" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.683581" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.040514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.294035" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.637761" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.410863" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.487784" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.007788" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.349194" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.421496" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.436318" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.840416" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.188575" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.625694" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.671964" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.425221" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.944754" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.197100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.461516" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.757970" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.478350" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.338555" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.317519" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.863713" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.982661" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.397326" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.353168" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.273978" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.302424" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.750485" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.041323" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.940086" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.621490" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.491626" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.703124" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.036810" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.072897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.106108" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.609541" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.333691" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.733882" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.337314" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.860897" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.069647" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.549730" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.305927" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.726587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.704842" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.263797" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.326015" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.606771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.314922" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.824598" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.448261" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.563150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.639204" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.003157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.030088" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.494901" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.705889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.772795" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.014957" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.192562" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.699991" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.213507" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.437733" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.286704" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.206712" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.243400" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.292003" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.022437" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.147749" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.108639" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.759813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.063819" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.072442" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.700754" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.659800" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.029773" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.927805" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.514394" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.213099" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.327041" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.974074" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.101450" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.023362" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.101717" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.902140" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.677296" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.784975" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.724938" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.319282" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.082341" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.595592" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.392339" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.006333" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.311446" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.120838" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.693373" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.051139" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.452968" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.862132" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.273150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.171368" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.247837" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.291680" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.032327" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.574523" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.795867" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.413428" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.511175" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.492876" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.036028" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.615040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.416894" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.455431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.620402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.616692" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.735431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.878196" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.223219" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.226757" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.390029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.417504" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.042956" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.383550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.882941" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.893980" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.501824" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.933845" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.054242" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.738273" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.419250" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.894935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.978121" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.878798" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.322364" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.688835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.968106" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.191673" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.351488" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.640199" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.262017" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.727769" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.282356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.976974" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.861368" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.814512" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.624861" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.613401" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.054125" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.497265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.314364" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.818515" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.076615" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.580630" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.725372" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.286188" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.765587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.416895" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.143684" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.475034" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.897905" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.712064" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.380341" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.457642" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.018253" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.269205" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.279579" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.491514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.287829" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.847917" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.584714" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.972094" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.802265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.061345" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.058591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.442048" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.681813" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.999641" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.572105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.025612" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.861536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.690119" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.232881" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.761621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.068457" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.602347" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.606782" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.787658" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.755576" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.686513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.872312" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.659778" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.235153" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.192765" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.698616" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.124789" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.932066" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.851521" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.162489" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.133930" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.257240" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.342176" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.143417" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.422781" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.301883" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.301116" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.066190" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.283194" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.756871" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.092659" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.137177" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1E0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.944098" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.304514" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.110080" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.036842" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.979573" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.697769" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.908804" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.451672" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.862756" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.209282" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.598074" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.413899" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.153402" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.972764" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.375206" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.525446" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.385590" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.276151" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.596319" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.117036" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.484992" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.997707" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.233624" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.720621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.005718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.650923" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.316368" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.318857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.563310" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.962587" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.137173" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.559297" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.858265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.384197" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.636191" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.678433" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteral-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.480383" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.952410" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.236684" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.522138" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.949100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.653039" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.435629" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.806210" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.367218" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.138307" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.906704" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.633319" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.709334" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.687406" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.715909" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.404349" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.277096" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.888100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.507895" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.474299" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.302879" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.553020" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.366405" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:06.772536" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.737729" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.294606" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.285097" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.694614" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.329256" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.021938" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.961366" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.331879" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.517713" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.059605" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.325353" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.228934" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.484807" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.903599" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.956443" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.025850" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.276172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.299095" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.884694" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.612437" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.135941" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.770755" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.840688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.494640" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.085855" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.153443" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.610165" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.645403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.587331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.993044" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.470272" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.576040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.059033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.353367" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.448150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.662083" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.815119" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.740213" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.026558" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.505371" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.588364" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.128535" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.816513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.919653" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.981674" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.897823" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.268904" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.088936" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.608172" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.377138" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.840940" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.988725" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.445100" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.684572" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.782718" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.429094" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.014426" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.669341" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.634152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.326885" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.471322" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.479819" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.742588" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.001222" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.792312" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.830844" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.366040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.874036" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.990771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.991642" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.229010" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.232283" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.762626" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.465544" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.169780" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#simple-group> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.948002" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.961529" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.766164" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.280744" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.055203" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.097771" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.369617" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23_pass-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.042654" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.760270" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.441101" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2groupBnodeNested2groupIRIRef_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.927019" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.988120" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.580333" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.599628" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.373317" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.966329" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.182123" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.573878" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3NLex_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.252395" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.244009" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.791765" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:08.688534" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.284835" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.842837" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.941006" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.958883" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.574152" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.449059" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.426857" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.806481" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.265837" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.144294" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.998221" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.331105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.725201" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.338480" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.307626" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.287124" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.583977" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.300263" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.623022" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.721741" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotcloseCode1-p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.585618" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.655278" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3groupdotclosecard23Annot3Code2-p1p2p3X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.719089" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.278832" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.878568" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.211591" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.230462" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.695015" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.173557" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.664033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.804621" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.253697" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.734818" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.163982" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.035550" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.240676" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.267647" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.225516" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.635436" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.811040" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.267404" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.248160" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.835513" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.200312" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.385889" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.593082" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.127420" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.742590" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.827398" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.312583" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.024462" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.100849" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.007277" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.220608" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.933382" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.160230" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.067829" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.794395" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.892271" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.272739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.141933" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.628029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.077648" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.701719" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.204928" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.315635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:18.186719" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.901968" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.085105" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.737284" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.320935" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.910157" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.726431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.148775" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.693609" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.294196" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.590915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.407830" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.534915" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.650953" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.184685" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.773438" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.221403" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.220431" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.729952" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:09.544202" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.019572" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.834015" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.624442" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.297580" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.758888" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.799991" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.697126" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.852933" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.030608" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.691254" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.944794" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.967673" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.252101" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.119440" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.300778" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.541013" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.049855" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.668814" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.435825" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:05.104096" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.838484" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.778739" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.643996" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.157954" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.841129" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.708826" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.780425" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.674699" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.671304" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.362349" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.073701" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.786759" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.284728" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.575499" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.213462" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.671006" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:07.703802" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.659999" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.129265" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.027906" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.876164" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.272129" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.641183" ;
+            ns1:date "2019-07-10T23:20:14.835017" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotAIRIREF_pass> .
@@ -8521,142 +52,61 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.097791" ;
+            ns1:date "2019-07-10T23:19:14.841002" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1E0_fail> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.455106" ;
+            ns1:date "2019-07-10T23:19:56.499970" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_pass-lit-equal> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.741945" ;
+            ns1:date "2019-07-10T23:20:17.308156" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-long> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:01.234961" ;
+            ns1:date "2019-07-10T23:20:11.780137" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X2> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.611812" ;
+            ns1:date "2019-07-10T23:19:59.581961" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_fail> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.762672" ;
+            ns1:date "2019-07-10T23:20:14.499046" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3Eachdot3Extra_pass-iri1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.943194" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.712331" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.885779" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:10.571567" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.880986" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.064824" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.903032" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.449414" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.745316" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.467761" ;
+            ns1:date "2019-07-10T23:19:53.972410" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_fail-integer-low> .
@@ -8665,358 +115,79 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.598751" ;
+            ns1:date "2019-07-10T23:19:12.305789" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_nonLiteral> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:04.835650" ;
+            ns1:date "2019-07-10T23:19:52.977525" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_ab> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.640297" ;
+            ns1:date "2019-07-10T23:19:55.231132" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_fail-decimal-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.290034" ;
+            ns1:date "2019-07-10T23:20:15.060681" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCodeWithEscapes1_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.888375" ;
+            ns1:date "2019-07-10T23:20:00.496027" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-FR> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.277929" ;
+            ns1:date "2019-07-10T23:20:14.049733" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_higher> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.855097" ;
+            ns1:date "2019-07-10T23:19:11.737060" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex-HYPHEN_MINUS_pass-noOthers> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.741794" ;
+            ns1:date "2019-07-10T23:19:55.663162" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.304836" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.307027" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.686374" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.180439" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.545502" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.542940" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.002115" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.677852" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.500919" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.799561" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.533635" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.442128" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.915688" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.854336" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.386894" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.166901" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.781150" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.847356" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.551226" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3groupdotExtra3_pass-iri2> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.593137" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.868298" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.876266" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.032429" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.248840" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.059563" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__passIo1> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.923029" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.288424" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.589729" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:16.488151" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.600017" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.381033" ;
-            earl:outcome earl:passed ] ;
-    earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
-
-[] a earl:Assertion ;
-    earl:assertedBy <https://github.com/hsolbrig> ;
-    earl:mode earl:automatic ;
-    earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.883575" ;
+            ns1:date "2019-07-10T23:19:58.624301" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v1> .
@@ -9025,106 +196,853 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.342961" ;
+            ns1:date "2019-07-10T23:19:34.883336" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32768_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.132076" ;
+            ns1:date "2019-07-10T23:19:52.095955" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-open> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.708343" ;
+            ns1:date "2019-07-10T23:19:52.016517" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:03.480112" ;
+            ns1:date "2019-07-10T23:19:53.810663" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_fail-high> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:15.136123" ;
+            ns1:date "2019-07-10T23:19:36.200333" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32768_fail> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.847450" ;
+            ns1:date "2019-07-10T23:19:18.660947" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-INF_fail> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:11.966549" ;
+            ns1:date "2019-07-10T23:19:54.043815" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_fail-integer-low> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:00.508224" ;
+            ns1:date "2019-07-10T23:19:37.199675" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-127_pass> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.567118" ;
+            ns1:date "2019-07-10T23:19:51.813917" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass0> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.241366" ;
+            ns1:date "2019-07-10T23:19:52.705687" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_0_0e0> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:14.272281" ;
+            ns1:date "2019-07-10T23:20:10.314076" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:13.764483" ;
+            ns1:date "2019-07-10T23:19:55.435183" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.571170" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:50.954655" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:32.820893" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.788165" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.360779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.852398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:13.033598" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.589136" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:36.549086" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n128_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.915542" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.801288" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.910080" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.815816" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.431841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.146317" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.969966" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.907207" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.671397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.126478" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:39.546478" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:34.184072" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.126781" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.371299" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.109671" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteral-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.010482" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.802673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.216823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.225106" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.346558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.343872" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.242430" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.437251" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.790903" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.081050" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.953784" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_fail-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.157152" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.712177" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.367993" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.749801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_fail2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.246243" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.241718" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.006896" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.569964" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.118033" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.569836" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.001001" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:33.848770" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.231681" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:15.155313" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.329749" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.603311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.893309" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:28.399585" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:21.315651" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.958164" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.537245" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.331819" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.679462" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.241162" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dT_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.324306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.474072" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.234067" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.687065" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-bel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.473962" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:46.233464" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-a_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:44.792883" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-256_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.983306" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.932043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.170241" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:14.550247" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.328185" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_failLAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.040429" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_fail_lower> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.831493" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.972185" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.506284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:35.213591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.526029" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.409008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.512054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.940149" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.256704" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.668417" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.011746" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-CarrotbcDollar> .
@@ -9133,16 +1051,4093 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:17.680659" ;
+            ns1:date "2019-07-10T23:19:55.832536" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-equal> .
 
 [] a earl:Assertion ;
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:12.405650" ;
+            ns1:date "2019-07-10T23:19:55.900373" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.619238" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.259497" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.847437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Adot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.289023" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.394504" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.320606" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.914361" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.570397" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.988083" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.950398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:19.307055" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.503040" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.064056" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-integer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:46.852684" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-true_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.297489" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.944626" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.213887" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.073680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:47.140052" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.349755" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:45.079100" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.672325" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_0_0e0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.381155" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.479266" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3EachdotExtra3_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.170851" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.602848" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.187120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:50.048308" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-10_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.942830" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:39.869943" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.764029" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.764395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.105606" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.627284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.139664" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.363393" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.103422" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.769829" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.425720" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.742991" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.409543" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.439890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.877960" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.666943" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.712511" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.701538" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.312148" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.353924" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:43.330988" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.576120" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.902614" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.129159" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.931784" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.253779" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.684411" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2SingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.379778" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v1v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.709529" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.220562" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.471929" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.533778" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2Eachdot> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:27.722180" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.142361" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.383661" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.339786" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.641245" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNex_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.174906" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusivexsd-byte_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.706284" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.501830" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALintLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.170599" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.239681" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:20.977632" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1elowercase0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.030566" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnode_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.516812" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.181161" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:30.696732" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.301143" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:43.032271" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65535_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.385441" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.696512" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.404692" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStem_failLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.966374" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_true> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.136918" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.219809" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.308909" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.973673" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_BNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:14.255403" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1.0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:28.722522" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.298680" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.488780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_pass-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.854823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.936860" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.121036" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.528705" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:25.737077" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1e0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:20.271289" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.742864" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.954446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.462431" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.354771" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.365490" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.677917" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.357162" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFExtra1_pass-iri-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.033877" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.014868" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.956137" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:38.879172" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.942907" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveBNode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.384995" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.794595" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.091162" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:47.707954" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.065664" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.889760" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.048799" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g2-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.747874" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.605186" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.576876" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3Eachdot3Extra_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.991510" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1language_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.821323" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.508949" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.362113" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.785458" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.963226" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.957453" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_IRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:38.198207" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-128_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.541619" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.292686" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.950385" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.526658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.114420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.162958" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:31.426040" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.918402" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:34.565585" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.345919" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.751398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-bnode-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.265797" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.573552" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.149486" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.947151" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_missingSelfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.848448" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.497361" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.425810" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.570135" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.956572" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iri_failv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:31.081810" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-p0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.833881" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.911280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.449130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.434599" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.558831" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.690423" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.982533" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.999013" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStarPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.033415" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1refbnode1_fail-g1-arc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.201889" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_pass-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.288029" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.954671" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.994190" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.800763" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.206917" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.781668" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.955094" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotAIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.184011" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.283355" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.930116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.172287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.370904" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.153914" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_pass-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.248827" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.588895" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.810727" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.884944" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.486022" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_ascii_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.269293" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.695656" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.411457" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.392726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dotExtra-someOf_pass_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.667131" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.042337" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.871154" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.511914" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.711174" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.582225" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.920014" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.278957" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.995984" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.711156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.601233" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.965237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.640010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.811008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.377445" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:40.197398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:23.388669" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.970118" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.230472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.668963" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNS2_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.524605" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:22.725530" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.703529" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.152400" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:16.365879" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.976687" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.473400" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.359123" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.221797" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#false-lead-excluding-value-shape> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.732157" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.360797" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.198460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.276237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.375618" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.606337" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.987285" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-bcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.916030" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open1dotOneopen2dotcloseclose_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.416272" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.031477" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMAL_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.286340" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGERLead_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.400113" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.070423" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExtern_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.334833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-string-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.790451" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.458539" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.169476" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRef1_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.527955" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.091623" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.333952" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.684815" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.081771" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.895750" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.031013" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotClosed_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.127990" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.802642" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.871744" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.807042" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:44.204280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-255_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.711385" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.250915" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.960061" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.653460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.229151" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.367684" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.940391" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapePlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.549193" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.391395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLE_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.929574" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.271223" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.741578" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.889452" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.269785" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.743081" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.655997" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass5> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.522389" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dot_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.519980" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3EachdotExtra3NLex_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.321045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_langString> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.260425" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.121782" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.499203" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failAll> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.030906" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.478886" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.834656" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LaLTen-fr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.866538" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.123368" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.825940" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.890446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMAL_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.581398" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:40.543292" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.664898" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.089014" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_other_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.263533" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.181543" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2EachBnodeNested2EachIRIRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.926796" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.102019" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.774075" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.515726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-byte-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.211158" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_fail-literalIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:13.664151" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.030828" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.296481" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.185913" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.072347" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:47.991432" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.565058" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.650628" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.526319" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-d_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.560331" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStem_passv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.288920" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_missingSelfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.978819" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.275563" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:31.797122" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:26.727347" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.761390" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.750525" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.779551" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.138751" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.545557" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.897212" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.497553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-into> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.686905" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.312221" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.901184" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.185392" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeRef1_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.859543" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.489992" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.852018" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.490626" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.134920" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.756778" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PTstar-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.675074" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.888068" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-StartlitEnd-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.629483" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:45.366321" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.468006" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:19.630228" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.372078" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.653443" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.409824" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.899545" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.683644" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.799361" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarTstar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.055916" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.273679" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.881353" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralLength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.665798" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_pass-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:44.483959" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.797556" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.284511" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1Closed_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.368973" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypelangString_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.704688" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.760644" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.285253" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.307008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.939250" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.148505" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.630316" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DECIMAL_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.516550" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.828521" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_literalANDvs__passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.892790" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LaDTbloodType> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.996657" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.945372" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iri_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.548762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.413843" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.559759" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.164593" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.602320" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_ascii_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.941883" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPattern_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.853685" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.723420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNSdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.924576" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_false> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.849252" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnotSTRING_LITERAL1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.046507" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.371437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefIRIREF1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.190665" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.464788" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-blowercaseC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.823078" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_pass_bare> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:24.749571" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.054328" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.087796" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_pass-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.196553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDOUBLEint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.774247" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.644038" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.300823" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.759864" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.318658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.018923" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.866798" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2dot_fail-empty-err> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.063058" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literal_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.626189" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr-FR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.218576" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#FocusIRI2EachBnodeNested2EachIRIRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.756866" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.909924" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.614761" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-NoShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.176258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.099801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:43.922045" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedByte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.399904" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:41.250221" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.816065" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.885121" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ANDvs_failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.633092" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.786969" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.050650" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.879112" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDECIMAL_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:01.058052" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.077662" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.643424" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.643364" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.227894" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.131312" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3circRefPlus1_pass-recursiveData> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.922568" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.140404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.879932" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.509155" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalLength_fail-lit-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.738258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.252030" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.143468" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.616115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.248050" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.012730" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.675055" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.695288" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMAL_pass-float-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:45.945547" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-empty_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.232679" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.133140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.766885" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_fail-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:47.424471" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.614887" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:41.962341" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.879470" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFDatatype_LabDTbloodType999> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.329315" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.411420" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.321562" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.383593" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:22.027905" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.810654" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.187633" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.616941" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1X2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:28.064647" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.563613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTIRI_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.818617" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen-fr-jura> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.322588" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.579928" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.255129" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.263951" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.403275" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.835376" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.660892" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLE_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.671930" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.443039" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRILength_dot_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.842234" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.715296" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.145260" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1Shape2Shape3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.667484" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.065615" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.111134" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLEintLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.273794" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-iri> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.158557" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.575587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.866169" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveINTEGERLead_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.253081" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:17.962480" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.687724" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.697346" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTdot_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.592990" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_passIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.011411" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.059870" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.552788" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.611295" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfrc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.054033" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:38.550113" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:22.352455" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-nINF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.443575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.790484" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
     earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxinclusiveINTEGER_pass-low> .
@@ -9151,10 +5146,4015 @@
     earl:assertedBy <https://github.com/hsolbrig> ;
     earl:mode earl:automatic ;
     earl:result [ a earl:TestResult ;
-            ns1:date "2019-03-08T18:50:02.026506" ;
+            ns1:date "2019-07-10T23:20:00.724441" ;
             earl:outcome earl:passed ] ;
     earl:subject <https://pypi.org/project/PyShEx/> ;
-    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-1E0_fail> .
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot_pass_p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.965280" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_pass-bc> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.960693" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.698737" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.355580" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.583410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:29.059541" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.823663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.771497" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:49.739067" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-2_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.709335" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.029027" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.043211" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Eachdotclosecard23Annot3Code2-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.478826" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.386043" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.519709" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.913609" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.575026" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_23ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.237488" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.934988" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1true_ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.985559" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.194076" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_fail-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:43.632693" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-65536_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:12.136695" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open4Onedotclosecard23_fail-p1p2p3p4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.318514" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.252740" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.470764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.414064" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.722258" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.846615" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#P2T2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.085562" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.296637" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.900645" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalStartPatternEnd_CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.131148" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.147174" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.839317" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_bare_pass_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.373523" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.197410" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveINTEGER_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:30.040460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-a1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.275354" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:16.676872" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:25.097833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.695884" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.346130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.994818" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.677895" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:23.065919" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:40.890020" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedLong-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.859650" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternEnd_fail-litEnd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.822200" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.584436" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_decimal-1_2345ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.775535" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLE_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:37.860126" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-n129_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.719747" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.566202" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.944530" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.283086" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.360110" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#skipped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.561950" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.082551" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusBNODE_empty_fail-iriFocusLabel> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.857388" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_pass-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.631483" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.381097" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.076712" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.099650" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.101277" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.131729" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDOUBLE_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.899620" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referrer,referent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.846610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.698791" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStemMinusliteraliri3_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:49.447921" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.063632" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.268047" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteral_fail-literal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.385156" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.206635" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_fail-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.008780" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsANDvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.402841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLELeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:13.961337" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.206638" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.812259" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.872591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.592148" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLELeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.947028" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.778774" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.275438" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_selfReference> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.040332" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.375432" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-ab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.036561" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.928726" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_IntoReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.824971" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedot_pass-over_lexicallyLater> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.311446" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.721103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.877834" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.041933" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.132037" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.331844" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.480004" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.064334" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_fail-literalIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.457003" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.640346" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTNOTvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.856847" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:15.449968" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-INF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.624897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:23.717331" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.208658" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.425502" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.936199" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.960189" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.561242" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_failLAtfr-ch> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.692001" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.978289" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_pass-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.990705" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDECIMALint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.605472" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3EachdotExtra3NLex_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.473951" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.410206" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:17.318240" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.746706" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxexclusiveINTEGER_pass-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.883934" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRef1_referent,referrer> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.591486" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDECIMALint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.994541" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLE_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.727233" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_fail_escaped> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.243801" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.158610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1startReffail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.195009" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.741795" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.852966" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.537866" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.257424" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_fail-inNOT> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.051532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.007094" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.395006" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefbnode1_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.844675" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass6> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.563144" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.396074" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprOR3_passvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.354781" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.656585" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.988494" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_CyclicIRI_ShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.724561" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.341976" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.731380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.184939" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.506508" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.650257" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGERLead_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.680421" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.614056" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLEintLeadTrail_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.960307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.306774" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralMaxlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.109772" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.656858" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-cd> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.116491" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.444153" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.651341" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_fail-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.323848" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-dateTime-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.176569" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLE_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.680076" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startEqualSpaceInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.540628" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_fail-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.596210" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:19.948004" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.671116" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.754453" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveINTEGER_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.713091" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNdefault_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.085890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.956433" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1false_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.139098" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusvs_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.495222" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDOUBLE_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.985460" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:27.063849" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.900106" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.753846" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.526938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.262265" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.494734" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.601615" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.799277" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLELeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.067925" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#0focusIRI_empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.001613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.978336" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.453624" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-integer-longLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.254788" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.775848" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.315132" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.669350" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1dotMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.463454" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.358679" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGER_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.548164" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.733172" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardOpt_pass0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.845201" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.461591" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.428720" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.301219" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.995558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1a> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.547682" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#3EachdotExtra3_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:49.162708" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-fAlSe_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.414890" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPatternB-dot_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.513612" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern19_fail-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.345034" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val2IRIREFPlusExtra1_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.343707" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveINTEGER_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.783349" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-someOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.906379" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.742764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.298216" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.721985" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.484054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_failv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.551368" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.662234" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefbnode_fail-missing> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.422945" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.523989" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_UTF8_boundaries_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:29.711193" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-1a_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:16.059633" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.799437" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.406237" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-longLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.080570" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.335957" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-decimal-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.651917" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMinexclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.201651" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-xsd_integer-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.913938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#refBNodeORrefIRI_ReflexiveShortIRI> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.335610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_fail_p1p2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:21.642870" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.034820" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotNoCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.608375" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.859050" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPlus_Is1_Ip1_La,Io1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.064686" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefOR3_passShape1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.633351" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteral3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:36.878613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.453575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-BC> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.762299" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.553786" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-float-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.822921" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotPlusAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.686638" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2Star_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.662642" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTdot_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.089103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxexclusiveDECIMAL_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.772745" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardPlus_fail0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.395191" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_pass-decimal-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.216678" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_failLAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.765979" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.260548" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprRefOR3_passvc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.364639" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMaxLength-dot_fail-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.111719" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.573269" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.302700" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvsORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.449158" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveINTEGER_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.243430" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.336340" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_failIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.479334" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTIRI_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.394894" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusPattern-dot_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.764710" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.427568" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1One_pass-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.633349" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-others_lexicallyEarlier> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.023181" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.369473" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiriStem3_v2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.443374" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.579040" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card2_fail3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.207085" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMaxlength_pass-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.916663" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.830783" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_fail-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.650166" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.833515" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1cardStar_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:27.390643" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-pINF_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.325426" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1NOTvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.482634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMinexclusiveDECIMAL_pass-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:48.280523" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-TRUE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:37.528115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#byte-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.757414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_fail_escapes> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.158312" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-decimal-longTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.841675" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.241395" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxexclusiveDOUBLE_fail-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.470304" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1STRING_LITERAL1_with_all_controls_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.422183" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMinexclusiveDOUBLE_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.174967" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveDECIMALint_fail-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.730130" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2EachInclude1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.101103" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3EachdotcloseCode1-p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:33.514290" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#int-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.327239" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.491383" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_pass-integer-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:17.639341" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-empty_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.119524" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.314129" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overReferrer,overReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.468273" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.585311" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dot-base_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.742119" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDECIMALLeadTrail_pass-float-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.641736" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStemMinuslanguageStem3_LAtfr-be> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.636338" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveINTEGER_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.601352" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literaliriStem_fail-Iv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.517334" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open2Eachdotclosecard25c1dot> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.310938" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodePattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.843099" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveDOUBLEintLeadTrail_fail-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.163558" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.203270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-val> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.211474" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_pass-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.043401" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriMinlength_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:26.381504" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-INF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.686374" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:48.569911" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-FALSE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.197139" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.556487" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_failvc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:35.541092" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-32767_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.070710" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDOUBLELeadTrail_pass-double-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.914086" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_fail-double-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.541897" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1nonliteralPattern_fail-bnode-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.761552" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1refvsMinusiri3_v3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.924860" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMininclusiveDECIMALLeadTrail_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:45.657249" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#positiveInteger-0_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.276746" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLEintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.593821" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-malformedxsd_integer-1_2345> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:12.230196" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusnonLiteralLength-nonLiteralLength_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.322613" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nPlus1-greedy-rewrite> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.604509" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.450309" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1Length_fail-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.761764" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotOne2dot-oneOf_fail_p1p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.961513" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3AND1_fail-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:30.368610" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#negativeInteger-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.457575" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMALLeadTrail_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.585020" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_00> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.921330" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveDOUBLE_pass-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.167054" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:18.982553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.616161" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-bnode> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:32.149270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.038841" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.013057" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vShapeANDRef3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.030877" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.174587" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStemMinusiri3_passIv4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.126414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusdatatype_pass-empty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.797307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1bnodeLength_fail-lit-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:33.186163" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.428508" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatterni_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.612553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_fail1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:24.049102" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.097611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:32.482660" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#long-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:39.215302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonNegativeInteger-p0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.661670" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#NOT1dotOR2dotX3_pass-Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.638404" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.603641" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTvs_failempty> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:26.060136" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-NaN_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:48.873196" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-tRuE_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.225154" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.027520" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxexclusiveDOUBLEint_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.384762" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveINTEGERLead_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.127720" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriPattern_pass-iri-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.920377" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAnnotIRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.559506" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_fail-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.482115" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.932494" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsANDvs__passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.289532" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDOUBLE_fail-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:41.577139" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.288895" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGER_fail-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.241347" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#focusNOTRefOR1dot_pass-inOR> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.867760" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxinclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.099057" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusIRI_dot_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.331743" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMinexclusiveDECIMAL_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.395791" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.705008" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1AND1Ref3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.022667" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotCode3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.314998" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_passLAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:16.992794" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.457865" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literal_passv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.498939" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1AND1Ref3_pass-vc1vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.867408" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.645782" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1iriRefLength1_fail-iri-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.822363" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDOUBLE_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.007674" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1datatypeLength_fail-wrongDatatype> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:59.828282" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literalStemMinusliteralStem3_passLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.624415" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#PstarT-greedy> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.694507" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1DOUBLElowercase_fail-0E0> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.368226" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1languageStem_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:51.621705" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1card25_pass2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.420623" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.747332" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_REGEXP_escapes_escaped_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.861422" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExprAND3_failvc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.219843" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsORdatatype_fail-dt> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.865534" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.355678" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREF_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.119569" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_pass-decimal-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.779773" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#2OneInclude1-after_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.111172" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.859287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralANDvs_failIo1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.051321" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTRefOR1dot_pass-other> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.000494" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveINTEGERLead_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.720900" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMininclusiveINTEGER_pass-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.624270" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startRefIRIREF_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.228909" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOT_vsORvs__failIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.446571" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotExtra1_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.378146" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1AND1OR1Ref3_pass-vc1vc2vc3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.189414" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1vExpr1OR1OR1Ref3_passvc1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.548072" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDOUBLE_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.539750" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalTotaldigits_fail-byte-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:10.750005" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTliteral_ANDvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.706698" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard2_pass-p1p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.529190" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1literallanguageStemMinusliterallanguage3_failLAtfr-BE> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.785132" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1floatMaxinclusiveDECIMAL_pass-float-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.897044" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1inversedotAnnot3_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:24.374299" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-p1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.152724" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMinexclusiveINTEGER_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:13.986209" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Eachdotclosecard23_pass-p1p2p3X3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.328010" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotInline1_overMatchesReferent> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.538469" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.587390" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotRefAND3_failShape1Shape2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:25.425934" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#double-1E0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.170307" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_failLv> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:15.764931" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-n1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.982990" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1iriStem_passv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.907566" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#open3Onedotclosecard23_fail-p1X4> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.604106" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotSemi_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:15.183140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startCode3fail_abort> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.802389" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1LANGTAG_LabLTen> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.549197" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMaxinclusiveINTEGER_pass-integer-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:18.313134" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#decimal-NaN_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.524302" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_fail-bnode-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:11.699234" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotLNexSingleComment_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.209271" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDOUBLELeadTrail_pass-integer-equalLead> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.429674" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEintLeadTrail_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.317553" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFClosedExtra1_fail-iri2_higher> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:52.640225" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1INTEGER_Lab> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.273611" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#openopen1dotOne1dotclose1dotclose_pass_p2p3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.274291" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveINTEGER_fail-double-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:13.346911" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#integer-1_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.335833" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusMinLength-dot_pass-iri-long> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:00.202249" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1emptylanguageStemMinuslanguageStem3_LAtfr> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:42.357775" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedInt-n1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.927814" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalCarrotPatternDollar_pass-CarrotbcDollar> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:18.117245" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#shapeExternRef_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:17.172770" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1focusvsANDIRI_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:35.871933" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#short-n32769_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:58.067052" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_with_all_meta_pass-NA> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:42.707810" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#unsignedShort-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:20.621795" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#float-p1.0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.351141" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPattern_pass-lit-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.347310" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDECIMALint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.209136" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1_NOTvs_ORvs_passIv3> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:09.443922" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1dotShapeAND1dot3X_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.089500" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALint_fail-integer-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:29.391287" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#nonPositiveInteger-p1_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.159773" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1integerMininclusiveDECIMALintLeadTrail_pass-integer-high> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:54.431990" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMininclusiveDECIMAL_pass-decimal-equalLeadTrail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.688818" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#startSpaceEqualInline_pass-noOthers> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.873366" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalPatternDollar_pass-litDollar-match> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:14.378380" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1val1IRIREFExtra1p2_fail-iri2> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:50.358297" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#boolean-01_fail> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:50.656960" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#dateTime-dt_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:46.556649" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#string-0_pass> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:20:11.146140" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1NOTliteralORvs_passIv1> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:55.698718" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1decimalMaxinclusiveDOUBLE_pass-decimal-low> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:56.417634" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1doubleMaxexclusiveDOUBLEint_fail-double-equal> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:57.152099" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalMaxlength_pass-lit-short> .
+
+[] a earl:Assertion ;
+    earl:assertedBy <https://github.com/hsolbrig> ;
+    earl:mode earl:automatic ;
+    earl:result [ a earl:TestResult ;
+            ns1:date "2019-07-10T23:19:53.239936" ;
+            earl:outcome earl:passed ] ;
+    earl:subject <https://pypi.org/project/PyShEx/> ;
+    earl:test <https://raw.githubusercontent.com/shexSpec/shexTest/master/validation/manifest#1literalFractiondigits_fail-malformedxsd_decimal-1_23ab> .
 
 [] dc:issued "2018-11-13"^^xsd:date ;
     foaf:maker <https://github.com/hsolbrig> ;

--- a/tests/test_issues/test_issue_51.py
+++ b/tests/test_issues/test_issue_51.py
@@ -1,0 +1,63 @@
+import unittest
+from pprint import pprint
+
+from rdflib import Graph, Namespace, RDF
+
+from pyshex import ShExEvaluator
+
+BASE = Namespace("https://w3id.org/biolink/vocab/")
+
+rdf = f"""
+@prefix : <{BASE}> .
+@prefix rdf: <{RDF}> .
+:s rdf:type :X .
+"""
+
+shex = f"""
+BASE <{BASE}>
+
+<BiologicalProcess> ( 
+    {{
+        ( $<BiologicalProcess_tes> a [ <BiologicalProcessOrActivity> ] ?;
+          a [ <BiologicalProcess> ]
+        )
+    }} OR @<X>
+)
+
+<X> {{&<BiologicalProcess_tes>; a [<X>]}}
+"""
+
+shex2 = f"""
+BASE <{BASE}>
+
+<BiologicalProcess> ( 
+    {{
+        ( $<BiologicalProcess_tes> a [ <BiologicalProcessOrActivity> ] ?;
+          a [ <BiologicalProcess> ]
+        )
+    }} OR @<X>
+)
+
+<X> {{&<missing>}}
+"""
+
+BASE = Namespace("https://w3id.org/biolink/vocab/")
+
+
+class Issue51TestCase(unittest.TestCase):
+    def test_inner_te(self):
+        """ Test recognition of an inner triple expression """
+
+        e = ShExEvaluator(rdf=rdf, schema=shex, focus=BASE.s, start=BASE.X).evaluate()
+        self.assertTrue(e[0].result)
+
+    def test_te_message(self):
+        """ Test the error message (and eventually the startup test) """
+        e = ShExEvaluator(rdf=rdf, schema=shex2, focus=BASE.s, start=BASE.X).evaluate()
+        self.assertFalse(e[0].result)
+        self.assertEqual('  Testing :s against shape https://w3id.org/biolink/vocab/X\n'
+                         '    https://w3id.org/biolink/vocab/missing: Reference not found', e[0].reason)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_issues/test_reactome.py
+++ b/tests/test_issues/test_reactome.py
@@ -10,6 +10,7 @@ class ReactomeTestCase(WikiDataTestCase):
     # Note: This test has never been run past 1
     expected_results = [True, False, False, False, False, True, False, False]
 
+    @unittest.skipIf(True, "Awaiting User-Agent fix (issue 52)")
     def test_wikidata_reactome(self):
         test_data_base = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data', 'wikidata', 'reactome'))
 
@@ -20,7 +21,6 @@ class ReactomeTestCase(WikiDataTestCase):
             print(f"{'CONFORMS' if rslt.result else 'FAIL'}: {rslt.focus}")
         self.assertTrue(all(expected == actual for expected, actual in zip([r.result for r in rslts],
                                                                             self.expected_results)))
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This does not address the other part of issue #51 -- unresolved labels
are not detected until referenced.  It should be noted, however, that,
at the moment, unresolved shape references are not detected either.