### PR TITLE
Fix #75

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Topic :: Software Development :: Compilers
     License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 keywords =


### PR DESCRIPTION
PyShEx is compatible with python => 3.7. Removed the indication that it works with 3.6 