### PR TITLE
Declare support of 3.9 and 3.10; add testing/declare support for 3.11 and 3.12; start to fixup tox

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, "3.10" ]
+        python-version: [ 3.7, 3.8, 3.9, "3.10", "3.11", "3.12" ]
 
     steps:
     - uses: actions/checkout@v2

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,8 @@ Egon Willighagen <egon.willighagen@gmail.com>
 Harold Solbrig <hsolbri1@MacBook-Pro.local>
 Harold Solbrig <solbrig@earthlink.net>
 Harold Solbrig <solbrig@jhu.edu>
+Josh Moore <josh@openmicroscopy.org>
+Yaroslav Halchenko <debian@onerussian.com>
 andrawaag <andra@micelio.be>
 hsolbrig <solbrig.harold@mayo.edu>
 hsolbrig <solbrig@earthlink.net>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,21 @@
 CHANGES
 =======
 
+* Allow pytest for tox
+* running tests (tox) updated CHANGES
+* Running tests (tox) added me (Yaroslav Halchenko) and Josh Moore into AUTHORS, thanks
+* Fix tox.ini envlist needing "," as separator
+* Add testing/declare 3.11 and 3.12 as supported
+* Declare 3.9 and 3.10 as supported since tested against already
+* Enable codecov
+
+v0.8.1
+------
+
+* Fix lru\_cache option
+* Remove the separate pr-test file.  The main catches it
+* Update requirements file
+* Fix for issue #81
 * Replace '/' with '\'
 
 v0.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 keywords =
     ShEx
     rdf

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 keywords =
     ShEx
     rdf

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py37,py38,py39,py310,py311,py312
 [testenv]
 deps=unittest2
 whitelist_externals = python
+allowlist_externals =
+    pytest
 setenv =
      IN_TOX = true
      SKIP_EXTERNAL_URLS = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37 py38 py39 py310 py311 py312
+envlist = py37,py38,py39,py310,py311,py312
 
 [testenv]
 deps=unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37 py38 py39 py310
+envlist = py37 py38 py39 py310 py311 py312
 
 [testenv]
 deps=unittest2


### PR DESCRIPTION
Individual commits have more... ran out of time to resolve properly: I do not see declaration of dependencies in setup.cfg or similar location which renders `tox` testing not operational locally for me since it doesn't install any dependencies for the environment.